### PR TITLE
Fix tests by removing __init__.py imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## Unreleased
+
+### Fixed
+- Fix tests for Django >= 1.9 by removing model imports from `__init__.py`.
+
+
 ## 0.0.1 - 2017-01-31
 
 ### Added

--- a/flags/__init__.py
+++ b/flags/__init__.py
@@ -1,8 +1,0 @@
-from flags.template_functions import (
-    flag_enabled,
-    flags_enabled,
-    flag_disabled
-)
-from flags.decorators import flag_required
-
-__all__ = ['flag_enabled', 'flags_enabled', 'flag_disabled', 'flag_required']


### PR DESCRIPTION
Even though it's convenient for package users to expose methods from `flags.decorators` and `flags.template_functions` in the main `__init__.py`, it breaks tests for Django >= 1.9 because those methods import models that aren't ready at package import time.

This PR removes those imports (meaning that package users will have to refer to `flags.decorators. flag_required` instead of just `flags.flag_required`).

It might be possible to refactor those files so that models aren't loaded at import time -- I'm not sure how other packages handle this, but the few I looked at seem to avoid doing these kinds of deep imports at the top level like this.