### PR TITLE
Django template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,40 +3,134 @@
 [![Build Status](https://travis-ci.org/cfpb/wagtail-flags.svg?branch=master)](https://travis-ci.org/cfpb/wagtail-flags)
 [![Coverage Status](https://coveralls.io/repos/github/cfpb/wagtail-flags/badge.svg?branch=master)](https://coveralls.io/github/cfpb/wagtail-flags?branch=master)
 
-Feature flags allow you to toggle functionality within a Wagtail site via the admin without multiple deployments. Wagtail-Flags lets you use feature flags that are set in the Wagtail admin.
+Feature flags allow you to toggle functionality without multiple deployments. Wagtail-Flags lets you use feature flags that are set in the Wagtail admin.
 
 ![Feature flags in the Wagtail admin](screenshot.png)
 
-**Status**: Alpha. See the [CHANGELOG](CHANGELOG.md) for important developments.
 
 ## Dependencies
 
- * Django
- * Wagtail
- * Python
+- Django 1.8+
+- Wagtail 1.7+
+- Python 2.7+, 3.5+
+ 
 
 ## Installation
 
-1. Navigate to a local project folder on your computer.
-1. Clone this project into that folder with `git clone git@github.com:cfpb/wagtail-flags.git`.
-2. Install a Wagtail project into that same folder, such as [cfgov-refresh](https://github.com/cfpb/cfgov-refresh).
-3. From the Wagtail project folder, run `pip install -e ../wagtail-flags/` so that this project gets referenced.
+1. Install wagtail-flags using pip:
 
-## Configuration
+   ```shell
+pip install git+https://github.com/cfpb/wagtail-flags.git
+```
 
-To be added…
+2. Add `flags` as an installed app in your Django `settings.py`:
+
+   ```python
+ INSTALLED_APPS = (
+     ...
+     'flags',
+     ...
+ )
+```
+
 
 ## Usage
 
-To be added…
+Feature flags in Wagtail-Flags are stored in the database, exposed to Wagtail users through the Wagtail admin, and their state is associated with a [Wagtail Site](http://docs.wagtail.io/en/stable/reference/pages/model_reference.html#site).
 
-## How to test the software
+### Basic usage
 
-To be added…
+The Wagtail-Flags app provides two basic functions to check the status of feature flags, and one shortcut for checking the status of multiple flags.
 
-## Known issues
+- `flag_enabled` will return True if the feature flag is enabled. 
 
-To be added…
+- `flag_disabled` will return True if the feature flag is disabled or does not exist.
+
+- `flags_enabled` will return True only if all the given flags are enabled.
+
+
+### In Python
+
+In Python these functions can be imported from `flags.template_functions` and require a request object as the first argument (the request is used to check the flag's state for the requested Wagtail Site).
+
+```python
+from flags.template_functions import (
+    flag_enabled,
+    flag_disabled,
+    flags_enabled
+)
+
+if flag_enabled(request, 'BETA_NOTICE'):
+	print(“Beta notice banner will be displayed”)
+
+if flag_disabled(request, 'BETA_NOTICE'):
+	print(“Beta notice banner will not be displayed”)
+
+if flags_enabled(request, 'FLAG1', 'FLAG2', 'FLAG3'):
+	print(“All flags were set”)
+```
+
+In addition, a `flag_required` decorator is provided to require a particular flag for a Django view. The default behavior is to return a 404 if the flag is not set, but an optional fallback view function can be specified instead.
+
+```python
+from flags.decorators import flag_required
+
+@flag_required('MY_FLAG')
+def view_requiring_flag(request):
+    retrun HttpResponse('flag was set')
+
+def other_view(request):
+    return HttpResponse('flag was not set')
+
+@flag_required('MY_FLAG', fallback_view=other_view)
+def view_with_fallback(request):
+    return HttpResponse('flag was set')
+```
+
+
+### In Django templates
+
+In Django templates you'll need to load the `feature_flags` template tag library. You can then use `flag_enabled`, `flag_disabled`, and `flags_enabled` tags:
+
+```django
+{% load feature_flags %}
+{% flag_enabled 'BETA_NOTICE' as beta_flag %}
+{% if beta_flag %}
+  <div class="m-global-banner">
+    I’m a beta banner.   
+  </div>
+{% endif %}
+```
+
+
+### In Jinja2 templates
+
+The `flag_enabled`, `flag_disabled`, and `flags_enabled` functions can also be added to a Jinja2 environment and subsequently used in templates:
+
+```python
+from flags.template_functions import (
+    flag_enabled,
+    flag_disabled,
+    flags_enabled
+)
+
+...
+
+env.globals.update(
+    flag_enabled=flag_enabled,
+    flag_disabled=flag_disabled,
+    flags_enabled=flags_enabled
+)
+```
+
+```jinja
+{% if flag_enabled(request, 'BETA_NOTICE') %}
+  <div class="m-global-banner">
+    I’m a beta banner.   
+  </div>
+{% endif %}
+```
+
 
 ## Getting help
 

--- a/flags/templatetags/feature_flags.py
+++ b/flags/templatetags/feature_flags.py
@@ -1,0 +1,31 @@
+from django import template
+
+from flags.template_functions import (
+    flag_enabled as base_flag_enabled,
+    flags_enabled as base_flags_enabled,
+    flag_disabled as base_flag_disabled
+)
+
+
+register = template.Library()
+
+
+# @register.simple_tag(takes_context=True)
+@register.assignment_tag(takes_context=True)
+def flag_enabled(context, key):
+    request = context['request']
+    return base_flag_enabled(request, key)
+
+
+# @register.simple_tag(takes_context=True)
+@register.assignment_tag(takes_context=True)
+def flags_enabled(context, *keys):
+    request = context['request']
+    return all(base_flags_enabled(request, key) for key in keys)
+
+
+# @register.simple_tag(takes_context=True)
+@register.assignment_tag(takes_context=True)
+def flag_disabled(context, key):
+    request = context['request']
+    return base_flag_disabled(request, key)

--- a/flags/tests/test_templatetags_feature_flags.py
+++ b/flags/tests/test_templatetags_feature_flags.py
@@ -1,0 +1,113 @@
+from django.http import HttpRequest
+from django.template import Context, Template
+from django.test import TestCase
+
+from wagtail.wagtailcore.models import Site
+
+from flags.models import Flag
+
+
+class FlagsTemplateTagsTestCase(TestCase):
+
+    def setUp(self):
+        self.flag_names = ('ONE', 'TWO', 'THREE')
+        self.site = Site.objects.get(is_default_site=True)
+        self.request = HttpRequest()
+        self.request.site = self.site
+
+    def render_template(self, string, context=None):
+        context = context or {'request': self.request}
+        context = Context(context)
+        return Template(string).render(context)
+
+    def test_flag_enabled_disabled(self):
+        rendered = self.render_template(
+            '{% load feature_flags %}'
+            '{% flag_enabled "TEMPLATETAG_TEST"  as test_flag %}'
+            '{% if test_flag %}'
+            'flag enabled'
+            '{% else %}'
+            'flag disabled'
+            '{% endif %}'
+        )
+        self.assertEqual(rendered, 'flag disabled')
+
+    def test_flag_enabled_enabled(self):
+        Flag.objects.create(key='TEMPLATETAG_TEST', enabled_by_default=True)
+        rendered = self.render_template(
+            '{% load feature_flags %}'
+            '{% flag_enabled "TEMPLATETAG_TEST"  as test_flag %}'
+            '{% if test_flag %}'
+            'flag enabled'
+            '{% else %}'
+            'flag disabled'
+            '{% endif %}'
+        )
+        self.assertEqual(rendered, 'flag enabled')
+
+    def test_flag_disabled_disabled(self):
+        # Disabled can also mean non-existent
+        rendered = self.render_template(
+            '{% load feature_flags %}'
+            '{% flag_disabled "TEMPLATETAG_TEST"  as test_flag %}'
+            '{% if test_flag %}'
+            'flag disabled'
+            '{% else %}'
+            'flag enabled'
+            '{% endif %}'
+        )
+        self.assertEqual(rendered, 'flag disabled')
+
+    def test_flag_disabled_enabled(self):
+        Flag.objects.create(key='TEMPLATETAG_TEST', enabled_by_default=True)
+        rendered = self.render_template(
+            '{% load feature_flags %}'
+            '{% flag_disabled "TEMPLATETAG_TEST"  as test_flag %}'
+            '{% if test_flag %}'
+            'flag disabled'
+            '{% else %}'
+            'flag enabled'
+            '{% endif %}'
+        )
+        self.assertEqual(rendered, 'flag enabled')
+
+    def test_flags_enabled_all_disabled(self):
+        rendered = self.render_template(
+            '{% load feature_flags %}'
+            '{% flags_enabled "ONE" "TWO" "THREE"  as test_flag %}'
+            '{% if test_flag %}'
+            'all flags enabled'
+            '{% else %}'
+            'flags disabled'
+            '{% endif %}'
+        )
+        self.assertEqual(rendered, 'flags disabled')
+
+    def test_flags_enabled_some_enabled(self):
+        Flag.objects.create(key='ONE', enabled_by_default=True)
+        Flag.objects.create(key='TWO', enabled_by_default=True)
+        rendered = self.render_template(
+            '{% load feature_flags %}'
+            '{% flags_enabled "ONE" "TWO" "THREE"  as test_flag %}'
+            '{% if test_flag %}'
+            'all flags enabled'
+            '{% else %}'
+            'flags disabled'
+            '{% endif %}'
+        )
+        self.assertEqual(rendered, 'flags disabled')
+
+    def test_flags_enabled_all_enabled(self):
+        Flag.objects.create(key='ONE', enabled_by_default=True)
+        Flag.objects.create(key='TWO', enabled_by_default=True)
+        Flag.objects.create(key='THREE', enabled_by_default=True)
+        rendered = self.render_template(
+            '{% load feature_flags %}'
+            '{% flags_enabled "ONE" "TWO" "THREE"  as test_flag %}'
+            '{% if test_flag %}'
+            'all flags enabled'
+            '{% else %}'
+            'flags disabled'
+            '{% endif %}'
+        )
+        self.assertEqual(rendered, 'all flags enabled')

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist=py{27,35}-dj{18,19,110}-wag{17,18},flake8
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
     coverage erase
-    coverage run --source='.' {envbindir}/django-admin.py test {posargs}
+    coverage run --source='flags' {envbindir}/django-admin.py test {posargs}
 setenv=
     DJANGO_SETTINGS_MODULE=flags.tests.settings
 
@@ -34,6 +34,3 @@ exclude=
     .tox,
     __pycache__,
     flags/migrations/*
-
-[run]
-omit=.tox/*


### PR DESCRIPTION
Our flags implementation originally just supported our use of Jinja2 templates in https://github.com/cfpb/cfgov-refresh. However, as we expand their use (partially through this app!), and for potential Wagtail users who aren't using Jinja2 we need to support Django templates too. 

Here I've added `flag_enabled`, `flag_disabled`, and `flags_enabled` as Django template tags. I've also fleshed out the [README](https://github.com/cfpb/wagtail-flags/blob/django-templates/README.md) somewhat and fixed coverage reporting in `tox.ini`.