### PR TITLE
Fix the admin delete URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 1.0.2
+
+- Fix the admin delete URL #6
+
 ## 1.0.1
 
 -  Add a MANIFEST.in file #5

--- a/flags/wagtail_hooks.py
+++ b/flags/wagtail_hooks.py
@@ -20,7 +20,7 @@ def register_flag_admin_urls():
                 url(r'^$', views.select_site, name='select_site'),
                 url(r'^(\d+)/$', views.index, name='list'),
                 url(r'^(\d+)/save/$', views.save, name='save'),
-                url(r'^(\w+)/delete/$', views.delete, name='delete'),
+                url(r'^(.+)/delete/$', views.delete, name='delete'),
                 url(r'^create/$', views.create, name='create'),
             ], namespace='flagadmin'))
     ]

--- a/flags/wagtail_hooks.py
+++ b/flags/wagtail_hooks.py
@@ -20,7 +20,7 @@ def register_flag_admin_urls():
                 url(r'^$', views.select_site, name='select_site'),
                 url(r'^(\d+)/$', views.index, name='list'),
                 url(r'^(\d+)/save/$', views.save, name='save'),
-                url(r'^(.+)/delete/$', views.delete, name='delete'),
+                url(r'^([-a-zA-Z0-9_]+)/delete/$', views.delete, name='delete'),
                 url(r'^create/$', views.create, name='create'),
             ], namespace='flagadmin'))
     ]

--- a/flags/wagtail_hooks.py
+++ b/flags/wagtail_hooks.py
@@ -20,7 +20,8 @@ def register_flag_admin_urls():
                 url(r'^$', views.select_site, name='select_site'),
                 url(r'^(\d+)/$', views.index, name='list'),
                 url(r'^(\d+)/save/$', views.save, name='save'),
-                url(r'^([-a-zA-Z0-9_]+)/delete/$', views.delete, name='delete'),
+                url(r'^([-a-zA-Z0-9_]+)/delete/$', views.delete,
+                    name='delete'),
                 url(r'^create/$', views.create, name='create'),
             ], namespace='flagadmin'))
     ]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author='CFPB',
     author_email='tech@cfpb.gov',
     license='CC0',
-    version='1.0.1',
+    version='1.0.2',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
If a flag like `FOO-BAR` exists, then a delete URL would fail to resolve because it matched `\w+`. This PR changes it to match `.+`, so that flag names can be anything for the purposes of the admin URL matching.