### PR TITLE
Add support for include()'ed URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ def view_with_fallback(request):
 
 **Note**, because flags that do not exist are taken to be `False` by default, `@flag_check('MY_FLAG', False)` and `@flag_check('MY_FLAG', None)` will both succeed if `MY_FLAG` does not exist.
 
-For URL handling, there is `flagged_url()` which can be used in place of Django's `url()`. **Note**, it will not work for `include()` url.
+For URL handling, there is `flagged_url()` which can be used in place of Django's `url()`. `fallback` support for `include()` URLs is limited to a single view.
 
 ```python
 from flags.urls import flagged_url
@@ -118,6 +118,8 @@ from flags.urls import flagged_url
 urlpatterns = [
     flagged_url('MY_FLAG', r'^an-url$', view_requiring_flag, condition=True),
     flagged_url('MY_FLAG_WITH_FALLBACK', r'^another-url$', view_with_fallback,
+                condition=True, fallback=other_view)
+    flagged_url('MY_FLAGGED_INCLUDE', r'^myapp$', include('myapp.urls'),
                 condition=True, fallback=other_view)
 ]
 

--- a/flags/tests/test_urls.py
+++ b/flags/tests/test_urls.py
@@ -14,6 +14,7 @@ def view(request):
 def fallback(request):
     return HttpResponse('fallback')
 
+
 extra_patterns = [
     url(r'^included-url$', view),
 ]

--- a/flags/tests/test_urls.py
+++ b/flags/tests/test_urls.py
@@ -14,6 +14,9 @@ def view(request):
 def fallback(request):
     return HttpResponse('fallback')
 
+extra_patterns = [
+    url(r'^included-url$', view),
+]
 
 urlpatterns = [
     flagged_url('FLAGGED_URL', r'^url-true-no-fallback$', view,
@@ -24,6 +27,15 @@ urlpatterns = [
                 name='some-view', condition=True, fallback=fallback),
     flagged_url('FLAGGED_URL', r'^url-false-fallback$', view,
                 name='some-view', condition=False, fallback=fallback),
+
+    flagged_url('FLAGGED_URL', r'^include/', include(extra_patterns),
+                condition=True),
+    flagged_url('FLAGGED_URL', r'^include-false/', include(extra_patterns),
+                condition=False),
+    flagged_url('FLAGGED_URL', r'^include-fallback/', include(extra_patterns),
+                condition=True, fallback=fallback),
+    flagged_url('FLAGGED_URL', r'^include-false-fallback/',
+                include(extra_patterns), condition=True, fallback=fallback),
 ]
 
 
@@ -105,11 +117,49 @@ class FlagCheckTestCase(TestCase):
 
         self.assertContains(response, 'fallback')
 
-    def test_flagged_url_include(self):
-        with self.assertRaises(TypeError):
-            flagged_url('MY_FLAG', r'^my_url/$', include([
-                url(r'^my_included_url', view)
-            ]))
+    def test_flagged_url_true_include_true(self):
+        Flag.objects.create(key=self.flag_name, enabled_by_default=True)
+
+        request = self.factory.get('/include/included-url')
+        resolved_view, args, kwargs = resolve('/include/included-url')
+        response = resolved_view(request)
+
+        self.assertContains(response, 'view')
+
+    def test_flagged_url_true_include_false(self):
+        Flag.objects.create(key=self.flag_name, enabled_by_default=False)
+
+        request = self.factory.get('/include/included-url')
+        resolved_view, args, kwargs = resolve('/include/included-url')
+        with self.assertRaises(Http404):
+            resolved_view(request)
+
+    def test_flagged_url_false_include(self):
+        Flag.objects.create(key=self.flag_name, enabled_by_default=False)
+
+        request = self.factory.get('/include-false/included-url')
+        resolved_view, args, kwargs = resolve('/include-false/included-url')
+        response = resolved_view(request)
+
+        self.assertContains(response, 'view')
+
+    def test_flagged_url_false_include_true(self):
+        Flag.objects.create(key=self.flag_name, enabled_by_default=True)
+
+        request = self.factory.get('/include-false/included-url')
+        resolved_view, args, kwargs = resolve('/include-false/included-url')
+        with self.assertRaises(Http404):
+            resolved_view(request)
+
+    def test_flagged_url_include_fallback(self):
+        Flag.objects.create(key=self.flag_name, enabled_by_default=False)
+
+        request = self.factory.get('/include-fallback/included-url')
+        resolved_view, args, kwargs = resolve(
+            '/include-fallback/included-url')
+        response = resolved_view(request)
+
+        self.assertContains(response, 'fallback')
 
     def test_flagged_url_not_callable(self):
         with self.assertRaises(TypeError):

--- a/flags/urls.py
+++ b/flags/urls.py
@@ -1,7 +1,13 @@
-from django.core.urlresolvers import (
-    RegexURLPattern,
-    RegexURLResolver
-)
+try:
+    from django.urls import (
+        RegexURLPattern,
+        RegexURLResolver
+    )
+except ImportError:
+    from django.core.urlresolvers import (
+        RegexURLPattern,
+        RegexURLResolver
+    )
 
 from flags.decorators import flag_check
 
@@ -22,7 +28,7 @@ class FlaggedURLResolver(RegexURLResolver):
         patterns = []
         for pattern in super(FlaggedURLResolver, self).url_patterns:
             flagged_pattern = RegexURLPattern(
-                pattern._regex, self.flag_decorator(pattern._callback),
+                pattern._regex, self.flag_decorator(pattern.callback),
                 pattern.default_args, pattern.name)
             patterns.append(flagged_pattern)
         return patterns

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author='CFPB',
     author_email='tech@cfpb.gov',
     license='CC0',
-    version='1.0.2',
+    version='1.0.3',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
This PR adds support for the Django URL `include()` function in `flagged_url()`.

It does this by returning a custom `RegexURLResolver` subclass when `include()` is encountered, `FlaggedURLResolver`, which overrides `url_patterns` and decorates all included URL pattern views.

This is necessary to support satellite app flagging in [cfgov-refresh](https://github.com/cfpb/cfgov-refresh). ([Here's an example](https://github.com/cfpb/cfgov-refresh/commit/1ba00b8225019637ed8fac1a4ac792cc40e917ff).)

This PR also bumps the version in setup.py anticipating a release.