### PR TITLE
Make flags with no conditions default to False

### DIFF
--- a/flags/settings.py
+++ b/flags/settings.py
@@ -55,8 +55,9 @@ class Flag:
 
     def check_state(self, **kwargs):
         """ Determine this flag's state based on its conditions """
-        condition_fns = self.conditions
-        return all(fn(v, **kwargs) for c, fn, v, o in condition_fns)
+        if len(self.conditions) == 0:
+            return False
+        return all(fn(v, **kwargs) for c, fn, v, o in self.conditions)
 
 
 def add_flags_from_sources(sources=None):

--- a/flags/settings.py
+++ b/flags/settings.py
@@ -4,6 +4,7 @@ from importlib import import_module
 
 from django.apps import apps
 from django.conf import settings
+from django.utils.functional import cached_property
 
 from flags.conditions import get_condition
 
@@ -29,7 +30,7 @@ class Flag:
         """ There can be only one feature flag of a given name """
         return other.name == self.name
 
-    @property
+    @cached_property
     def configured_conditions(self):
         """ Get all flag conditions configured in settings """
         # Get condition callables for our settings-configured conditions
@@ -38,7 +39,7 @@ class Flag:
                          for fn in get_condition(c)]
         return condition_fns
 
-    @property
+    @cached_property
     def dynamic_conditions(self):
         """ Get dynamic flag conditions from models.FlagState """
         # Get condition callables for our dynamic-configured conditions
@@ -48,7 +49,7 @@ class Flag:
                          for fn in get_condition(s.condition)]
         return condition_fns
 
-    @property
+    @cached_property
     def conditions(self):
         """ Get all flag conditions """
         return self.configured_conditions + self.dynamic_conditions

--- a/flags/tests/test_settings.py
+++ b/flags/tests/test_settings.py
@@ -50,6 +50,7 @@ class FlagTestCase(TestCase):
         flag = Flag('MY_FLAG', {})
         self.assertFalse(flag.check_state())
 
+
 class SettingsTestCase(TestCase):
 
     def tearDown(self):

--- a/flags/tests/test_settings.py
+++ b/flags/tests/test_settings.py
@@ -46,6 +46,9 @@ class FlagTestCase(TestCase):
         flag = Flag('MY_FLAG', {'boolean': True})
         self.assertTrue(flag.check_state())
 
+    def test_check_state_no_conditions(self):
+        flag = Flag('MY_FLAG', {})
+        self.assertFalse(flag.check_state())
 
 class SettingsTestCase(TestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description='Feature flags for Wagtail sites',
     long_description=long_description,
     license='CC0',
-    version='2.0.0',
+    version='2.0.1',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
With the great refactor in #9 and the addition of the concept of conditions, configurable functions all of which need to evaluate to `True` for a flag to be enabled, I accidentally allowed the possibility for a flag with no conditions to evaluate to `True`. 

This PR adds an explicit check for how many conditions a flag has and if it has none it will return `False`.