### PR TITLE
Add a context manager to flag multiple URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ def view_with_fallback(request):
 ### Flagged URLs
 
 ```python
-from flags.urls import flagged_url
+from flags.urls import flagged_url, flagged_urls
 ```
 
 #### `flagged_url(flag_name, regex, view, kwargs=None, name=None, state=True, fallback=None)`
@@ -283,6 +283,19 @@ urlpatterns = [
     flagged_url('MY_FLAGGED_INCLUDE', r'^myapp$', include('myapp.urls'),
                 state=True, fallback=other_view)
 ]
+```
+
+#### `flagged_urls(flag_name, state=True, fallback=None)`
+
+Flag multiple URLs in the same context. Returns function that can be used in place of Django's `url()` that wraps `flagged_url()`. Can take an optional fallback view that will apply to all urls.
+
+```python
+with flagged_urls('MY_FLAG') as url:
+    flagged_url_patterns = [
+        url(r'^an-url$', view_requiring_flag),
+    ]
+
+urlpatterns = urlpatterns + flagged_url_patterns
 ```
 
 ### Django templates

--- a/flags/urls.py
+++ b/flags/urls.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 try:
     from django.urls import (
         RegexURLPattern,
@@ -37,7 +39,6 @@ class FlaggedURLResolver(RegexURLResolver):
 def flagged_url(flag_name, regex, view, kwargs=None, name=None,
                 state=True, fallback=None):
     """ Make a URL depend on the state of a feature flag """
-
     if callable(view):
         flagged_view = flag_check(flag_name,
                                   state,
@@ -53,3 +54,13 @@ def flagged_url(flag_name, regex, view, kwargs=None, name=None,
 
     else:
         raise TypeError('view must be a callable')
+
+
+@contextmanager
+def flagged_urls(flag_name, state=True, fallback=None):
+    """ Flag multiple URLs in the same context
+    Returns a url()-compatible wrapper for flagged_url() """
+    def flagged_url_wrapper(regex, view, kwargs=None, name=None):
+        return flagged_url(flag_name, regex, view, kwargs=kwargs, name=name,
+                           state=state, fallback=fallback)
+    yield flagged_url_wrapper

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description='Feature flags for Wagtail sites',
     long_description=long_description,
     license='CC0',
-    version='2.0.1',
+    version='2.0.2',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
This PR makes flagging multiple Django URL patterns that are not `include()`s cleaner by providing a context manager. For example, instead of:

```python
urlpatterns = [
    flagged_url('MY_FLAG', r'^an-url$', urlView),
    flagged_url('MY_FLAG', r'^a-different-url$', differentUrlView),
    flagged_url('MY_FLAG', r'^one-more-url$', thirdUrlView),
]
```

You can now do this:

```python
with flagged_urls('MY_FLAG') as url:
    flagged_url_patterns = [
        url(r'^an-url$', urlView),
        url(r'^a-different-url$', differentUrlView),
        url(r'^one-more-url$', thirdUrlView),
    ]

urlpatterns = urlpatterns + flagged_url_patterns
```

Along with making a urls.py a bit cleaner and more consistent this should also make it easier to clean up feature flagged URLs.