### PR TITLE
Allow any of a flag's conditions to match (for path, user, site, etc)

### DIFF
--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -120,7 +120,10 @@ def site_condition(site_str, request=None, **kwargs):
         site_str += ':80'
 
     hostname, port = site_str.split(':')
-    conditional_site = Site.objects.get(hostname=hostname, port=port)
+    try:
+        conditional_site = Site.objects.get(hostname=hostname, port=port)
+    except ObjectDoesNotExist:
+        return False
 
     try:
         site = Site.find_for_request(request)

--- a/flags/settings.py
+++ b/flags/settings.py
@@ -55,10 +55,10 @@ class Flag:
         return self.configured_conditions + self.dynamic_conditions
 
     def check_state(self, **kwargs):
-        """ Determine this flag's state based on its conditions """
+        """ Determine this flag's state based on any of its conditions """
         if len(self.conditions) == 0:
             return False
-        return all(fn(v, **kwargs) for c, fn, v, o in self.conditions)
+        return any(fn(v, **kwargs) for c, fn, v, o in self.conditions)
 
 
 def add_flags_from_sources(sources=None):

--- a/flags/settings.py
+++ b/flags/settings.py
@@ -56,8 +56,6 @@ class Flag:
 
     def check_state(self, **kwargs):
         """ Determine this flag's state based on any of its conditions """
-        if len(self.conditions) == 0:
-            return False
         return any(fn(v, **kwargs) for c, fn, v, o in self.conditions)
 
 

--- a/flags/tests/settings.py
+++ b/flags/tests/settings.py
@@ -37,4 +37,5 @@ FLAGS = {
     'FLAG_ENABLED': {'boolean': True},
     'FLAG_ENABLED2': {'boolean': True},
     'FLAG_DISABLED': {'boolean': False},
+    'DB_FLAG': {},
 }

--- a/flags/tests/test_conditions.py
+++ b/flags/tests/test_conditions.py
@@ -167,6 +167,10 @@ class SiteConditionTestCase(TestCase):
     def test_site_valid_site(self):
         self.assertTrue(site_condition(str(self.site), request=self.request))
 
+    def test_site_invalid_site(self):
+        self.assertFalse(site_condition('non.existent.site',
+                                        request=self.request))
+
     def test_request_required(self):
         with self.assertRaises(RequiredForCondition):
             site_condition('localhost:80')

--- a/flags/tests/test_settings.py
+++ b/flags/tests/test_settings.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 from django.test import TestCase, override_settings
 
 import flags.settings
@@ -49,6 +51,11 @@ class FlagTestCase(TestCase):
     def test_check_state_no_conditions(self):
         flag = Flag('MY_FLAG', {})
         self.assertFalse(flag.check_state())
+
+    def test_check_state_multiple_conditions(self):
+        request = namedtuple('Request', ['path'])(path='/foo')
+        flag = Flag('MY_FLAG', {'boolean': False, 'path': '/foo'})
+        self.assertTrue(flag.check_state(request=request))
 
 
 class SettingsTestCase(TestCase):

--- a/flags/tests/test_settings.py
+++ b/flags/tests/test_settings.py
@@ -1,4 +1,7 @@
-from collections import namedtuple
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from django.test import TestCase, override_settings
 
@@ -53,7 +56,7 @@ class FlagTestCase(TestCase):
         self.assertFalse(flag.check_state())
 
     def test_check_state_multiple_conditions(self):
-        request = namedtuple('Request', ['path'])(path='/foo')
+        request = Mock(path='/foo')
         flag = Flag('MY_FLAG', {'boolean': False, 'path': '/foo'})
         self.assertTrue(flag.check_state(request=request))
 

--- a/flags/tests/test_state.py
+++ b/flags/tests/test_state.py
@@ -61,7 +61,7 @@ class FlagStateTestCase(TestCase):
         self.assertFalse(flag_state('DB_FLAG', request=self.request))
 
     def test_flag_state_site_for_multiple_sites(self):
-        """ A site flag enabled for another site should be False """
+        """ A site flag enabled for two sites should return True for both """
         other_site = Site.objects.create(
             is_default_site=False,
             root_page_id=self.site.root_page_id,

--- a/flags/tests/test_state.py
+++ b/flags/tests/test_state.py
@@ -34,7 +34,7 @@ class FlagStateTestCase(TestCase):
         FlagState.objects.create(name='FLAG_DISABLED',
                                  condition='site',
                                  value=str(self.site))
-        self.assertFalse(flag_state('FLAG_DISABLED', request=self.request))
+        self.assertTrue(flag_state('FLAG_DISABLED', request=self.request))
 
     def test_flag_state_bool_true_and_db_site_true(self):
         """ Test state of multiple conditions, one 'site' in database """
@@ -49,15 +49,31 @@ class FlagStateTestCase(TestCase):
                                     request=self.request))
 
     def test_flag_state_site_for_other_site(self):
-        """ A site flag enabled for an other site should be False """
+        """ A site flag enabled for another site should be False """
         other_site = Site.objects.create(
             is_default_site=False,
-            root_page_id=self.site.root_page_id
+            root_page_id=self.site.root_page_id,
+            hostname='other.host'
         )
-        FlagState.objects.create(name='FLAG_ENABLED',
+        FlagState.objects.create(name='DB_FLAG',
                                  condition='site',
                                  value=str(other_site))
-        self.assertFalse(flag_state('FLAG_ENABLED', request=self.request))
+        self.assertFalse(flag_state('DB_FLAG', request=self.request))
+
+    def test_flag_state_site_for_multiple_sites(self):
+        """ A site flag enabled for another site should be False """
+        other_site = Site.objects.create(
+            is_default_site=False,
+            root_page_id=self.site.root_page_id,
+            hostname='other.host'
+        )
+        FlagState.objects.create(name='DB_FLAG',
+                                 condition='site',
+                                 value=str(other_site))
+        FlagState.objects.create(name='DB_FLAG',
+                                 condition='site',
+                                 value=str(self.site))
+        self.assertTrue(flag_state('DB_FLAG', request=self.request))
 
     def test_flag_enabled_enabled(self):
         """ Global flags enabled should be True """

--- a/flags/views.py
+++ b/flags/views.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect, render
@@ -10,9 +12,10 @@ from flags.settings import get_flags
 
 
 def index(request):
+    flags = OrderedDict(sorted(get_flags().items(), key=lambda x: x[0]))
     context = {
         'flag_states': FlagState.objects.all(),
-        'flags': get_flags(),
+        'flags': flags,
     }
     return render(request, 'flagadmin/index.html', context)
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description='Feature flags for Wagtail sites',
     long_description=long_description,
     license='CC0',
-    version='2.0.2',
+    version='2.0.3',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
Previously, Wagtail-Flags 2.0 erroneously required *all* of a flag's conditions to match. This lead to situations where multiple "site" conditions would match none of their expected sites, multiple "path" conditions would match none of the possible paths, etc.

With this change we have a situation where multiple "boolean" or "anonymous" conditions can override a `False` one, which is less than desirable, but I'll have a separate fix for that.

This PR bumps the version to 2.0.3 in anticipation of release.