### PR TITLE
Add support for fallback includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ from flags.urls import flagged_url, flagged_urls
 
 Make a URL depend on the state of a feature flag. `flagged_url()` can be used in place of Django's `url()`.
 
-`fallback` support for `include()` URLs is limited to a single view rather than a fallback set of `include()`ed URLs.
+`fallback` can be a a set of `include()`ed patterns, but the regular expressions in the fallback includes must match the regular expression for the URL or includes *exactly*.
 
 ```python
 urlpatterns = [
@@ -282,6 +282,8 @@ urlpatterns = [
                 state=True, fallback=other_view)
     flagged_url('MY_FLAGGED_INCLUDE', r'^myapp$', include('myapp.urls'),
                 state=True, fallback=other_view)
+    flagged_url('MY_NEW_APP_FLAG', r'^mynewapp$', include('mynewapp.urls'),
+                state=True, fallback=include('myoldapp.urls'))
 ]
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description='Feature flags for Wagtail sites',
     long_description=long_description,
     license='CC0',
-    version='2.0.3',
+    version='2.0.4',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
This PR adds support for fallbacks that are `include()`ed URL patterns. Previously fallbacks for URLs could only be single views, even if the flagged URL was for an `include()`. Now if the flagged URL is an `include()` instead of a view, `fallback` can be an `include()` as well.

```python
flagged_url('MY_NEW_APP_FLAG', r'^mynewapp$', include('mynewapp.urls'),
            state=True, fallback=include('myoldapp.urls'))
```

If the fallback `include()` contains URL patterns that do not exist in the flagged `include()`, those URL patterns will be available when the flag is not in the defined state.