### PR TITLE
Bump Wagtail, Django, and Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: pip
 matrix:
   include:
     - env: TOXENV=flake8
-      python: 3.5
+      python: 3.6
     - env: TOXENV=py27-dj18-wag18
       python: 2.7
     - env: TOXENV=py27-dj18-wag19
@@ -23,24 +23,36 @@ matrix:
       python: 2.7
     - env: TOXENV=py27-dj110-wag110
       python: 2.7
-    - env: TOXENV=py35-dj18-wag18
-      python: 3.5
-    - env: TOXENV=py35-dj18-wag19
-      python: 3.5
-    - env: TOXENV=py35-dj18-wag110
-      python: 3.5
-    - env: TOXENV=py35-dj19-wag18
-      python: 3.5
-    - env: TOXENV=py35-dj19-wag19
-      python: 3.5
-    - env: TOXENV=py35-dj19-wag110
-      python: 3.5
-    - env: TOXENV=py35-dj110-wag18
-      python: 3.5
-    - env: TOXENV=py35-dj110-wag19
-      python: 3.5
-    - env: TOXENV=py35-dj110-wag110
-      python: 3.5
+    - env: TOXENV=py27-dj111-wag18
+      python: 2.7
+    - env: TOXENV=py27-dj111-wag19
+      python: 2.7
+    - env: TOXENV=py27-dj111-wag110
+      python: 2.7
+    - env: TOXENV=py36-dj18-wag18
+      python: 3.6
+    - env: TOXENV=py36-dj18-wag19
+      python: 3.6
+    - env: TOXENV=py36-dj18-wag110
+      python: 3.6
+    - env: TOXENV=py36-dj19-wag18
+      python: 3.6
+    - env: TOXENV=py36-dj19-wag19
+      python: 3.6
+    - env: TOXENV=py36-dj19-wag110
+      python: 3.6
+    - env: TOXENV=py36-dj110-wag18
+      python: 3.6
+    - env: TOXENV=py36-dj110-wag19
+      python: 3.6
+    - env: TOXENV=py36-dj110-wag110
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag18
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag19
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag110
+      python: 3.6
 
 install:
   pip install tox coveralls

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Feature flags allow you to toggle functionality in both Django settings and the 
 ## Dependencies
 
 - Django 1.8+
-- Wagtail 1.7+
-- Python 2.7+, 3.5+
+- Wagtail 1.8+
+- Python 2.7+, 3.6+
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ except (IOError, ImportError):
 
 
 install_requires = [
-    'Django>=1.8,<1.11',
-    'wagtail>=1.6,<1.9',
+    'Django>=1.8,<1.12',
+    'wagtail>=1.8,<1.11',
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,35}-dj{18,19,110}-wag{17,18,19,110},flake8
+envlist=py{27,36}-dj{18,19,110,111}-wag{18,19,110},flake8
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -12,20 +12,19 @@ setenv=
 
 basepython=
     py27: python2.7
-    py35: python3.5
+    py36: python3.6
 
 deps=
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
-    wag16: wagtail>=1.6,<1.7
-    wag17: wagtail>=1.7,<1.8
+    dj111: Django>=1.11,<1.12
     wag18: wagtail>=1.8,<1.9
     wag19: wagtail>=1.9,<1.10
     wag110: wagtail>=1.10,<1.11
 
 [testenv:flake8]
-basepython=python3.5
+basepython=python3.6
 deps=flake8>=2.2.0
 commands=flake8 .
 


### PR DESCRIPTION
This PR bumps the Wagtail requirement to include 1.10, bumps the Django version requirement to include 1.11, and bumps the Python 3 version in tests to 3.6.