### PR TITLE
Add an 'after date' condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ Allows a flag to be enabled for a Wagtail site that matches the hostname and por
 FLAGS = {'MY_FLAG': {'site': 'staging.mysite.com'}}
 ```
 
+##### `after date`
+
+Allows a flag to be enabled after a given date (and time) given in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601).
+
+```python
+FLAGS = {'MY_FLAG': {'after date': '2017-06-01T12:00'}}
+```
+
 ## API
 
 ### Flag state

--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils import timezone, dateparse
 
 # This will be maintained by register() as a global dictionary of
 # condition_name: [list of functions], so we can have multiple conditions
@@ -132,3 +133,22 @@ def site_condition(site_str, request=None, **kwargs):
         return False
 
     return conditional_site == site
+
+
+@register('after date')
+def date_condition(date_or_str, **kwargs):
+    """ Does the current date match the given date?
+    date_or_str is either a date object or an ISO 8601 string """
+    try:
+        date = dateparse.parse_datetime(date_or_str)
+    except TypeError:
+        date = date_or_str
+
+    now = timezone.now()
+
+    try:
+        date_test = (now >= date)
+    except TypeError:
+        date_test = False
+
+    return date_test

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description='Feature flags for Wagtail sites',
     long_description=long_description,
     license='CC0',
-    version='2.0.4',
+    version='2.0.5',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
This PR adds an 'after date' condition that will allow us to automatically enable a flag after a date and time given either as a Python `datetime` object (only in the Django `settings.py` file) or as an [ISO 8601 string](https://en.wikipedia.org/wiki/ISO_8601).

The example in the README is:

```python
FLAGS = {'MY_FLAG': {'after date': '2017-06-01T12:00'}}
```
