### PR TITLE
Describe possible 404s in flagged_url documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,11 +269,15 @@ def view_with_fallback(request):
 from flags.urls import flagged_url, flagged_urls
 ```
 
+Flagged URLs are an alternative to [flagging views with decorators](https://github.com/cfpb/wagtail-flags#flag_checkflag_name-state-fallbacknone-kwargs).
+
 #### `flagged_url(flag_name, regex, view, kwargs=None, name=None, state=True, fallback=None)`
 
 Make a URL depend on the state of a feature flag. `flagged_url()` can be used in place of Django's `url()`.
 
-`fallback` can be a a set of `include()`ed patterns, but the regular expressions in the fallback includes must match the regular expression for the URL or includes *exactly*.
+The `view` and the `fallback` can both be a a set of `include()`ed patterns but any matching URL patterns in the includes must match *exactly* in terms of regular expression, keyword arguments, and name, otherwise a `404` may be unexpectedly raised. 
+
+If a `fallback` is not given the flagged url will raise a `404` if the flag state does not match the required `state`. 
 
 ```python
 urlpatterns = [

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Flagged URLs are an alternative to [flagging views with decorators](https://gith
 
 Make a URL depend on the state of a feature flag. `flagged_url()` can be used in place of Django's `url()`.
 
-The `view` and the `fallback` can both be a a set of `include()`ed patterns but any matching URL patterns in the includes must match *exactly* in terms of regular expression, keyword arguments, and name, otherwise a `404` may be unexpectedly raised. 
+The `view` and the `fallback` can both be a set of `include()`ed patterns but any matching URL patterns in the includes must match *exactly* in terms of regular expression, keyword arguments, and name, otherwise a `404` may be unexpectedly raised. 
 
 If a `fallback` is not given the flagged url will raise a `404` if the flag state does not match the required `state`. 
 


### PR DESCRIPTION
I've attempted to expand the flagged_url documentation somewhat based on recent experiences with a migration in [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/pull/3017) where we failed to fully grasp the way flagged includes must match fallback includes.

That the included and fallback-included patterns must match *exactly* in regular expression, keyword arguments, and name is now called out explicitly, as as the reasons for possible 404s from flagged urls.