### PR TITLE
WIP? Rename "path" to "path start"

### DIFF
--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -91,7 +91,7 @@ def parameter_condition(param_name, request=None, **kwargs):
     return request.GET.get(param_name) == 'True'
 
 
-@register('path')
+@register('path start')
 def path_condition(path, request=None, **kwargs):
     """ Does the request's path match the given path? """
     if request is None:


### PR DESCRIPTION
To make it a bit clearer in the UI that the path condition matches on `startswith`.

This PR probably needs more work, and I want to make sure @willbarton gets a look at it, so I wanted to go ahead and open it so I don't forget to do it after he's back from his vacation.