### PR TITLE
Simplify the testing matrix and add isort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,53 +5,29 @@ matrix:
   include:
     - env: TOXENV=flake8
       python: 3.6
-    - env: TOXENV=py27-dj18-wag18
-      python: 2.7
-    - env: TOXENV=py27-dj18-wag19
-      python: 2.7
     - env: TOXENV=py27-dj18-wag110
       python: 2.7
-    - env: TOXENV=py27-dj19-wag18
+    - env: TOXENV=py27-dj18-wag112
       python: 2.7
-    - env: TOXENV=py27-dj19-wag19
-      python: 2.7
-    - env: TOXENV=py27-dj19-wag110
-      python: 2.7
-    - env: TOXENV=py27-dj110-wag18
-      python: 2.7
-    - env: TOXENV=py27-dj110-wag19
-      python: 2.7
-    - env: TOXENV=py27-dj110-wag110
-      python: 2.7
-    - env: TOXENV=py27-dj111-wag18
-      python: 2.7
-    - env: TOXENV=py27-dj111-wag19
+    - env: TOXENV=py27-dj18-wag113
       python: 2.7
     - env: TOXENV=py27-dj111-wag110
       python: 2.7
-    - env: TOXENV=py36-dj18-wag18
+    - env: TOXENV=py27-dj111-wag112
+      python: 2.7
+    - env: TOXENV=py27-dj111-wag113
+      python: 2.7
+    - env: TOXENV=36-dj18-wag110
+      python: 2.7
+    - env: TOXENV=36-dj18-wag112
+      python: 2.7
+    - env: TOXENV=36-dj18-wag113
+      python: 2.7
+    - env: TOXENV=36-dj111-wag110
       python: 3.6
-    - env: TOXENV=py36-dj18-wag19
+    - env: TOXENV=36-dj111-wag112
       python: 3.6
-    - env: TOXENV=py36-dj18-wag110
-      python: 3.6
-    - env: TOXENV=py36-dj19-wag18
-      python: 3.6
-    - env: TOXENV=py36-dj19-wag19
-      python: 3.6
-    - env: TOXENV=py36-dj19-wag110
-      python: 3.6
-    - env: TOXENV=py36-dj110-wag18
-      python: 3.6
-    - env: TOXENV=py36-dj110-wag19
-      python: 3.6
-    - env: TOXENV=py36-dj110-wag110
-      python: 3.6
-    - env: TOXENV=py36-dj111-wag18
-      python: 3.6
-    - env: TOXENV=py36-dj111-wag19
-      python: 3.6
-    - env: TOXENV=py36-dj111-wag110
+    - env: TOXENV=36-dj111-wag113
       python: 3.6
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: pip
 
 matrix:
   include:
-    - env: TOXENV=flake8
+    - env: TOXENV=lint
       python: 3.6
     - env: TOXENV=py27-dj18-wag110
       python: 2.7
@@ -17,17 +17,17 @@ matrix:
       python: 2.7
     - env: TOXENV=py27-dj111-wag113
       python: 2.7
-    - env: TOXENV=36-dj18-wag110
-      python: 2.7
-    - env: TOXENV=36-dj18-wag112
-      python: 2.7
-    - env: TOXENV=36-dj18-wag113
-      python: 2.7
-    - env: TOXENV=36-dj111-wag110
+    - env: TOXENV=py36-dj18-wag110
       python: 3.6
-    - env: TOXENV=36-dj111-wag112
+    - env: TOXENV=py36-dj18-wag112
       python: 3.6
-    - env: TOXENV=36-dj111-wag113
+    - env: TOXENV=py36-dj18-wag113
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag110
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag112
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag113
       python: 3.6
 
 install:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Feature flags allow you to toggle functionality in both Django settings and the 
 - [Installation](#installation)
 - [Concepts](#concepts)
 - [Usage](#usage)
-    - [Overview](#overview)
-    - [Adding Flags](#adding-flags)
-        - [Defining flags](#defining-flags)
-        - [Built-in conditions](#built-in-conditions)
+    - [Quickstart](#quickstart)
+    - [Defining flags](#defining-flags)
+    - [Using flags in code](#using-flags-in-code)
+    - [Built-in conditions](#built-in-conditions)
 - [API](#api)
     - [Flag state](#flag-state)
     - [Flag decorators](#flag-decorators)
@@ -30,7 +30,7 @@ Feature flags allow you to toggle functionality in both Django settings and the 
 ## Dependencies
 
 - Django 1.8+
-- Wagtail 1.8+
+- Wagtail 1.10+
 - Python 2.7+, 3.6+
 
 ## Installation
@@ -59,9 +59,9 @@ Conditions determine whether a flag is enabled or disabled by comparing a define
 
 ## Usage
 
-### Overview
+### Quickstart
 
-To use Wagtail-Flags you first need to define the flag, use the flag in code, and define conditions for the flag to be enabled.
+To use Wagtail-Flags you first need to define the flag, use the flag, and define conditions for the flag to be enabled.
 
 First, define the flag in Django `settings.py`:
 
@@ -104,7 +104,7 @@ Then visiting the URL `/mypage?enable_my_flag=True` should show you the flagged 
 
 ### Adding flags
 
-#### Defining flags
+### Defining flags
 
 Flags are defined in Django settings with the conditions in which they are enabled.
 
@@ -120,7 +120,53 @@ FLAGS = {
 
 The set of conditions can be none (flag will never be enabled), one (only condition that has to be met for the flag to be enabled), or many (all have to be met for the flag to be enabled).
 
-Additional conditions can be added in the Django or Wagtail admin for any defined flag (illustrated in [Usage](#usage)). Conditions added in the Django or Wagtail admin can be changed without restarting Django, conditions defined in `settings.py` cannot.
+Additional conditions can be added in the Django or Wagtail admin for any defined flag (illustrated in [Usage](#usage)). Conditions added in the Django or Wagtail admin can be changed without restarting Django, conditions defined in `settings.py` cannot. See below [for a list of built-in conditions](#built-in-conditions).
+
+### Using flags in code
+
+Flags can be used in Python code:
+
+```python
+from flags.state import flag_enabled
+
+if flag_enabled('MY_FLAG', request=a_request):
+	print("My feature flag is enabled")	
+```
+
+Django templates:
+
+```django
+{% flag_enabled 'MY_FLAG' as my_flag %}
+{% if my_flag %}
+  <div>
+    I’m the result of a feature flag.   
+  </div>
+{% endif %}
+```
+
+Jinja2 templates:
+
+```jinja
+{% if flag_enabled('MY_FLAG', request) %}
+  <div>
+    I’m the result of a feature flag.   
+  </div>
+{% endif %}
+```
+
+And Django `urls.py`:
+
+```python
+from flags.urls import flagged_url, flagged_urls
+
+urlpatterns = [
+    flagged_url('MY_FLAG', r'^an-url$', view_requiring_flag, state=True),
+]
+```
+
+See the [API documentation below](#api) for more details and examples.
+
+
 
 #### Built-in conditions
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ from django.conf.urls import url
 from django.views.generic.base import TemplateView
 
 urlpatterns = [
-    url(r'^/mypage$', TemplateView.as_view(template_name='mytemplate.html'),
+    url(r'^/mypage$', TemplateView.as_view(template_name='mytemplate.html')),
 ]
 ```
 
@@ -130,12 +130,13 @@ Flags can be used in Python code:
 from flags.state import flag_enabled
 
 if flag_enabled('MY_FLAG', request=a_request):
-	print("My feature flag is enabled")	
+    print("My feature flag is enabled")	
 ```
 
 Django templates:
 
 ```django
+{% load feature_flags %}
 {% flag_enabled 'MY_FLAG' as my_flag %}
 {% if my_flag %}
   <div>
@@ -144,7 +145,7 @@ Django templates:
 {% endif %}
 ```
 
-Jinja2 templates:
+Jinja2 templates (after [adding `flag_enabled` to the Jinja2 environment](#jinja2-templates)):
 
 ```jinja
 {% if flag_enabled('MY_FLAG', request) %}
@@ -401,9 +402,11 @@ from flags.template_functions import (
     flag_enabled,
     flag_disabled
 )
+from jinja2 import Environment
 
 ...
 
+env = Environment(…)
 env.globals.update(
     flag_enabled=flag_enabled,
     flag_disabled=flag_disabled
@@ -495,4 +498,4 @@ General instructions on _how_ to contribute can be found in [CONTRIBUTING](CONTR
 
 ## Credits and references
 
-1. Forked from [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/tree/master/cfgov/flags)
+1. Forked from [cfgov-refresh](https://github.com/cfpb/cfgov-refresh)

--- a/flags/admin.py
+++ b/flags/admin.py
@@ -2,4 +2,5 @@ from django.contrib import admin
 
 from flags.models import FlagState
 
+
 admin.site.register(FlagState)

--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -2,7 +2,8 @@ import re
 
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils import timezone, dateparse
+from django.utils import dateparse, timezone
+
 
 # This will be maintained by register() as a global dictionary of
 # condition_name: [list of functions], so we can have multiple conditions

--- a/flags/forms.py
+++ b/flags/forms.py
@@ -4,6 +4,7 @@ from flags.conditions import get_conditions
 from flags.models import FlagState
 from flags.settings import get_flags
 
+
 FLAGS_CHOICES = [(flag, flag) for flag in get_flags().keys()]
 CONDITIONS_CHOICES = [(c, c) for c in get_conditions()]
 

--- a/flags/settings.py
+++ b/flags/settings.py
@@ -1,5 +1,4 @@
 import logging
-
 from importlib import import_module
 
 from django.apps import apps
@@ -7,6 +6,7 @@ from django.conf import settings
 from django.utils.functional import cached_property
 
 from flags.conditions import get_condition
+
 
 logger = logging.getLogger(__name__)
 

--- a/flags/template_functions.py
+++ b/flags/template_functions.py
@@ -1,6 +1,6 @@
 from flags.state import (
+    flag_disabled as base_flag_disabled,
     flag_enabled as base_flag_enabled,
-    flag_disabled as base_flag_disabled
 )
 
 

--- a/flags/templatetags/feature_flags.py
+++ b/flags/templatetags/feature_flags.py
@@ -1,8 +1,8 @@
 from django import template
 
 from flags.state import (
+    flag_disabled as base_flag_disabled,
     flag_enabled as base_flag_enabled,
-    flag_disabled as base_flag_disabled
 )
 
 

--- a/flags/tests/settings.py
+++ b/flags/tests/settings.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
+
 SECRET_KEY = 'not needed'
 
 DATABASES = {

--- a/flags/tests/test_conditions.py
+++ b/flags/tests/test_conditions.py
@@ -1,5 +1,4 @@
 import importlib
-
 from datetime import timedelta
 
 from django.apps import apps
@@ -13,17 +12,16 @@ from wagtail.wagtailcore.models import Site
 from flags.conditions import (
     CONDITIONS,
     RequiredForCondition,
-    register,
-    get_condition,
-    boolean_condition,
-    user_condition,
     anonymous_condition,
+    boolean_condition,
+    date_condition,
+    get_condition,
     parameter_condition,
     path_condition,
+    register,
     site_condition,
-    date_condition,
+    user_condition,
 )
-
 from flags.models import FlagState
 
 

--- a/flags/tests/test_settings.py
+++ b/flags/tests/test_settings.py
@@ -6,15 +6,14 @@ except ImportError:
 from django.test import TestCase, override_settings
 
 import flags.settings
-
 from flags.models import FlagState
-
 from flags.settings import (
     DuplicateFlagException,
     Flag,
     add_flags_from_sources,
-    get_flags
+    get_flags,
 )
+
 
 # Test flag for using this module to test
 SOURCED_FLAG = True

--- a/flags/tests/test_state.py
+++ b/flags/tests/test_state.py
@@ -4,11 +4,7 @@ from django.test import TestCase
 from wagtail.wagtailcore.models import Site
 
 from flags.models import FlagState
-from flags.state import (
-    flag_state,
-    flag_enabled,
-    flag_disabled
-)
+from flags.state import flag_disabled, flag_enabled, flag_state
 
 
 class FlagStateTestCase(TestCase):

--- a/flags/tests/test_urls.py
+++ b/flags/tests/test_urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url, include
+from django.conf.urls import include, url
 from django.core.urlresolvers import resolve
-from django.http import HttpResponse, Http404
-from django.test import TestCase, RequestFactory, override_settings
+from django.http import Http404, HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
 
 from flags.urls import flagged_url, flagged_urls
 

--- a/flags/urls.py
+++ b/flags/urls.py
@@ -1,5 +1,8 @@
 from contextlib import contextmanager
 
+from flags.decorators import flag_check
+
+
 try:
     from django.urls import (
         RegexURLPattern,
@@ -10,8 +13,6 @@ except ImportError:
         RegexURLPattern,
         RegexURLResolver
     )
-
-from flags.decorators import flag_check
 
 
 class FlaggedURLResolver(RegexURLResolver):

--- a/flags/views.py
+++ b/flags/views.py
@@ -1,8 +1,7 @@
 from collections import OrderedDict
 
 from django.core.exceptions import ImproperlyConfigured
-from django.shortcuts import get_object_or_404
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import TemplateView
 
 from flags.decorators import flag_check

--- a/flags/wagtail_hooks.py
+++ b/flags/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 from django.core.urlresolvers import reverse
+
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
 

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,13 @@ except (IOError, ImportError):
 
 install_requires = [
     'Django>=1.8,<1.12',
-    'wagtail>=1.8,<1.11',
+    'wagtail>=1.10,<1.14',
 ]
 
 
 testing_extras = [
     'mock>=2.0.0',
     'coverage>=3.7.0',
-    'flake8>=2.2.0',
 ]
 
 
@@ -37,10 +36,8 @@ setup(
     },
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,36}-dj{18,111}-wag{110,112,113},flake8
+envlist=py{27,36}-dj{18,111}-wag{110,112,113},lint
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -21,10 +21,14 @@ deps=
     wag112: wagtail>=1.12,<1.13
     wag113: wagtail>=1.13,<1.14
 
-[testenv:flake8]
+[testenv:lint]
 basepython=python3.6
-deps=flake8>=2.2.0
-commands=flake8 .
+deps=
+    flake8>=2.2.0
+    isort>=4.2.15
+commands=
+    flake8 .
+    isort --check-only --diff --recursive flags
 
 [flake8]
 ignore=E731,W503
@@ -32,3 +36,18 @@ exclude=
     .tox,
     __pycache__,
     flags/migrations/*
+
+
+[isort]
+combine_as_imports=1
+lines_after_imports=2
+include_trailing_comma=1
+multi_line_output=3
+skip=.tox,migrations
+not_skip=__init__.py
+use_parentheses=1
+known_django=django
+known_wagtail=wagtail
+known_future_library=future,six
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,36}-dj{18,19,110,111}-wag{18,19,110},flake8
+envlist=py{27,36}-dj{18,111}-wag{110,112,113},flake8
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,12 +16,10 @@ basepython=
 
 deps=
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
-    dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<1.12
-    wag18: wagtail>=1.8,<1.9
-    wag19: wagtail>=1.9,<1.10
     wag110: wagtail>=1.10,<1.11
+    wag112: wagtail>=1.12,<1.13
+    wag113: wagtail>=1.13,<1.14
 
 [testenv:flake8]
 basepython=python3.6
@@ -29,8 +27,7 @@ deps=flake8>=2.2.0
 commands=flake8 .
 
 [flake8]
-# There's nothing wrong with assigning lambdas
-ignore=E731
+ignore=E731,W503
 exclude=
     .tox,
     __pycache__,


### PR DESCRIPTION
This PR does the following:

- Simplify our testing matrix to test against LTS versions of Django and Wagtail only (as well as Wagtail 1.10, which CFPB is still using)
- Updates the flake8 configuration and adds isort to comply with [CFPB's Python standards](https://github.com/cfpb/development/blob/master/standards/python.md) 
- Updates the README slightly.
  