### PR TITLE
Update docs regarding timestamps in UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,10 @@ FLAGS = {'MY_FLAG': {'site': 'staging.mysite.com'}}
 
 ##### `after date`
 
-Allows a flag to be enabled after a given date (and time) given in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601).
+Allows a flag to be enabled after a given date (and time) given in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601). The time must be specified either in UTC or as an offset from UTC.
 
 ```python
-FLAGS = {'MY_FLAG': {'after date': '2017-06-01T12:00'}}
+FLAGS = {'MY_FLAG': {'after date': '2017-06-01T12:00Z'}}
 ```
 
 ## API


### PR DESCRIPTION
This change updates the documentation of the "after date" condition to specify that the provided datetime string must be in UTC or be provided relative to UTC. Local (naive) timestamps are not supported by the current logic.

Closes #23.