### PR TITLE
Alphabetize flags and conditions

### DIFF
--- a/flags/forms.py
+++ b/flags/forms.py
@@ -5,8 +5,8 @@ from flags.models import FlagState
 from flags.settings import get_flags
 
 
-FLAGS_CHOICES = [(flag, flag) for flag in get_flags().keys()]
-CONDITIONS_CHOICES = [(c, c) for c in get_conditions()]
+FLAGS_CHOICES = [(flag, flag) for flag in sorted(get_flags().keys())]
+CONDITIONS_CHOICES = [(c, c) for c in sorted(get_conditions())]
 
 
 class FlagStateForm(forms.ModelForm):

--- a/flags/views.py
+++ b/flags/views.py
@@ -13,7 +13,7 @@ from flags.settings import get_flags
 def index(request):
     flags = OrderedDict(sorted(get_flags().items(), key=lambda x: x[0]))
     context = {
-        'flag_states': FlagState.objects.all(),
+        'flag_states': FlagState.objects.order_by('name'),
         'flags': flags,
     }
     return render(request, 'flagadmin/index.html', context)


### PR DESCRIPTION
This change modifes the list view and new flag view so that flag and
condition names are alphabetized properly throughout.

Current ordering:

![image](https://user-images.githubusercontent.com/654645/35743257-0a4fe460-080b-11e8-87c5-81c23fb62650.png)

Fixed ordering:

![image](https://user-images.githubusercontent.com/654645/35743264-13036ec4-080b-11e8-8389-f30d17e33567.png)