### PR TITLE
Add support for Django 2.1 and Wagtail 2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 long_description = open('README.md', 'r').read()
 
 install_requires = [
-    'wagtail>=1.10,<2.2',
+    'wagtail>=1.10,<2.3',
     'django-flags>=3.0,<4.0'
 ]
 
@@ -21,7 +21,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='3.0.0',
+    version='3.0.1',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,
@@ -33,6 +33,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
         'Framework :: Wagtail :: 2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{27,36}-dj{18,111}-wag{113},py{36}-dj{20}-wag{20,21}
+envlist=lint,py{27,36}-dj{18,111}-wag{113},py{36}-dj{20,21}-wag{20,21,22}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -19,9 +19,11 @@ deps=
     dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     wag113: wagtail>=1.13,<1.14
     wag20: wagtail>=2.0,<2.1
     wag21: wagtail>=2.1,<2.2
+    wag22: wagtail>=2.2,<2.3
 
 [testenv:lint]
 basepython=python3.6


### PR DESCRIPTION
This PR adds support for Django 2.1 and Wagtail 2.2 to our `setup.py` and tox. 