### PR TITLE
Expose non-existent conditions in the UI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='4.0.0',
+    version='4.0.1',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,

--- a/wagtailflags/templates/wagtailflags/index.html
+++ b/wagtailflags/templates/wagtailflags/index.html
@@ -35,6 +35,9 @@
                       {% endif %}
                       <td>is enabled when</td>
                       <td>
+                        {% if condition.fn is None %}
+                        <span title="condition does not exist" style="color: #e9b04d; font-family: wagtail;">!</span>
+                        {% endif %}
                         <b>{{ condition.condition }}</b>
                       </td>
                       <td>is</td>


### PR DESCRIPTION
It's possible for database-stored `FlagState` objects to have conditions assocaited with them that get removed. This change exposes that in the UI. `FlagStates` that have conditions that no longer exist will now appear in the UI like this:

![image](https://user-images.githubusercontent.com/10562538/48845310-2b165400-ed6a-11e8-91c8-8dfc319ce5ba.png)

In this example `site` no longer exists. This makes that evident. 

This is a companion to, but does not depend on, https://github.com/cfpb/django-flags/pull/15