### PR TITLE
Autoregister site condition on app ready

### DIFF
--- a/wagtailflags/__init__.py
+++ b/wagtailflags/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtailflags.apps.WagtailFlagsAppConfig'

--- a/wagtailflags/apps.py
+++ b/wagtailflags/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class WagtailFlagsAppConfig(AppConfig):
+    name = 'wagtailflags'
+    verbose_name = 'Wagtail Flags'
+
+    def ready(self):
+        # Import custom conditions to ensure that they get registered.
+        import wagtailflags.conditions  # noqa


### PR DESCRIPTION
This change adds a custom app config for the wagtailflags package, including a `ready()` method that ensures that the 'site' custom condition gets registered on Django startup.