### PR TITLE
Remove the word "optional" from the flag table

### DIFF
--- a/wagtailflags/templates/wagtailflags/includes/flag_index.html
+++ b/wagtailflags/templates/wagtailflags/includes/flag_index.html
@@ -29,8 +29,6 @@
                     <td>
                         {% if condition.required %}
                         Required
-                        {% else %}
-                        Optional
                         {% endif %}
                     </td>
                     <td>


### PR DESCRIPTION
This change corresponds to https://github.com/cfpb/django-flags/pull/48. The word "optional" to refer to non-required conditions is inaccurate. This change removes the one occurrence in Wagtail-Flags.