### PR TITLE
Return 404 for admin views for undefined flags

### DIFF
--- a/wagtailflags/tests/test_views.py
+++ b/wagtailflags/tests/test_views.py
@@ -59,6 +59,10 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         )
         self.assertContains(response, 'Flag named DBONLY_FLAG already exists')
 
+    def test_flag_index_nonexistent_flag_raises_404(self):
+        response = self.client.get('/admin/flags/THIS_FLAG_DOES_NOT_EXIST/')
+        self.assertEqual(response.status_code, 404)
+
     def test_flag_index(self):
         response = self.client.get('/admin/flags/FLAG_DISABLED/')
         self.assertEqual(response.status_code, 200)
@@ -133,6 +137,12 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         self.assertEqual(condition_query.first().condition, 'boolean')
         self.assertEqual(condition_query.first().value, 'False')
 
+    def test_create_flag_condition_nonexistent_flag_raises_404(self):
+        response = self.client.get(
+            '/admin/flags/THIS_FLAG_DOES_NOT_EXIST/create/'
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_create_flag_condition(self):
         response = self.client.get('/admin/flags/DBONLY_FLAG/create/')
         self.assertEqual(response.status_code, 200)
@@ -155,6 +165,10 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         }
         response = self.client.post('/admin/flags/DBONLY_FLAG/create/', params)
         self.assertRedirects(response, '/admin/flags/#DBONLY_FLAG')
+
+    def test_edit_flag_condition_nonexistent_flag_raises_404(self):
+        response = self.client.get('/admin/flags/THIS_FLAG_DOES_NOT_EXIST/99/')
+        self.assertEqual(response.status_code, 404)
 
     def test_edit_flag_condition(self):
         condition_obj = FlagState.objects.create(
@@ -200,6 +214,12 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
             params
         )
         self.assertRedirects(response, '/admin/flags/#DBONLY_FLAG')
+
+    def test_delete_flag_condition_nonexistent_flag_raises_404(self):
+        response = self.client.get(
+            '/admin/flags/THIS_FLAG_DOES_NOT_EXIST/99/delete/'
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_delete_flag_condition(self):
         condition_obj = FlagState.objects.create(

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render, resolve_url
 
 from flags.models import FlagState
@@ -50,6 +51,9 @@ def create_flag(request):
 def flag_index(request, name):
     flag = get_flags().get(name)
 
+    if not flag:
+        raise Http404
+
     # If there's a database boolean condition, fetch it and treat it as a
     # on/off switch
     if 'enable' in request.GET or 'disable' in request.GET:
@@ -96,6 +100,10 @@ def flag_index(request, name):
 
 def edit_condition(request, name, condition_pk=None):
     flag = get_flags().get(name)
+
+    if not flag:
+        raise Http404
+
     try:
         condition = FlagState.objects.get(pk=condition_pk)
     except FlagState.DoesNotExist:
@@ -134,6 +142,10 @@ def edit_condition(request, name, condition_pk=None):
 
 def delete_condition(request, name, condition_pk):
     flag = get_flags().get(name)
+
+    if not flag:
+        raise Http404
+
     condition = get_object_or_404(FlagState, pk=condition_pk)
 
     if request.method == 'POST':


### PR DESCRIPTION
Currently a 500 error will be returned if an undefined flag name is used in the URL for an admin view. This is caused by an underlying AttributeError due to referencing a null Flag object.

This change properly returns 404 instead.

To test, visit a URL like this:

http://localhost:8000/admin/flags/THIS_FLAG_DOES_NOT_EXIST/