### PR TITLE
Support Wagtail 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py27-dj111-wag113
-      python: 2.7
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
     - env: TOXENV=py36-dj111-wag22
@@ -16,7 +14,7 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj21-wag24 
       python: 3.6
-    - env: TOXENV=py36-dj22-wag25 
+    - env: TOXENV=py36-dj22-wag27
       python: 3.6
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj22-wag23
       python: 3.6
-    - env: TOXENV=py36-dj22-wag24
+    - env: TOXENV=py36-dj22-wag27
       python: 3.6
-    - env: TOXENV=py37-dj22-wag24
+    - env: TOXENV=py37-dj22-wag27
       python: 3.7
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj22-wag27
       python: 3.6
+    - env: TOXENV=py37-dj22-wag27
+      python: 3.7
 
 install:
   pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
-    - env: TOXENV=py36-dj111-wag22
+    - env: TOXENV=py36-dj111-wag23
       python: 3.6
-    - env: TOXENV=py36-dj21-wag23 
+    - env: TOXENV=py36-dj20-wag23
       python: 3.6
-    - env: TOXENV=py36-dj21-wag24 
+    - env: TOXENV=py36-dj22-wag23
       python: 3.6
-    - env: TOXENV=py36-dj22-wag27
+    - env: TOXENV=py36-dj22-wag24
       python: 3.6
-    - env: TOXENV=py37-dj22-wag27
+    - env: TOXENV=py36-dj22-wag24
       python: 3.7
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj22-wag23
       python: 3.6
-    - env: TOXENV=py36-dj22-wag27
+    - env: TOXENV=py36-dj22-wag28
       python: 3.6
-    - env: TOXENV=py38-dj22-wag27
+    - env: TOXENV=py38-dj22-wag28
       python: 3.8
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj22-wag27
       python: 3.6
-    - env: TOXENV=py37-dj22-wag27
-      python: 3.7
+    - env: TOXENV=py38-dj22-wag27
+      python: 3.8
 
 install:
   pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj22-wag24
       python: 3.6
-    - env: TOXENV=py36-dj22-wag24
+    - env: TOXENV=py37-dj22-wag24
       python: 3.7
 
 install:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 
 ## Dependencies
 
-- Python 2.7+, 3.6+
+- Python 3.6+
 - Django 1.11+, 2.0+
 - Wagtail 1.13+, 2.0+
 - Django-Flags 4.2+ 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 
 ## Dependencies
 
-- Python 3.6+
-- Django 1.11+, 2.0+
-- Wagtail 1.13+, 2.0+
+- Python 3.6, 3.7, 3.8
+- Django 1.11, 2.0, 2.2
+- Wagtail 1.13, 2.3, 2.7
 - Django-Flags 4.2+ 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 
 ## Dependencies
 
-- Python 3.6, 3.7, 3.8
+- Python 3.6, 3.8
 - Django 1.11, 2.0, 2.2
 - Wagtail 1.13, 2.3, 2.7
 - Django-Flags 4.2+ 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 
 ## Dependencies
 
-- Python 3.6, 3.8
-- Django 1.11, 2.0, 2.2
-- Wagtail 1.13, 2.3, 2.8
+- Python 3
+- Django 1.11, 2.0-2.2
+- Wagtail 1.13, 2.3-2.8
 - Django-Flags 4.2+ 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 
 - Python 3.6, 3.8
 - Django 1.11, 2.0, 2.2
-- Wagtail 1.13, 2.3, 2.7
+- Wagtail 1.13, 2.3, 2.8
 - Django-Flags 4.2+ 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 
 ## Dependencies
 
-- Python 3
-- Django 1.11, 2.0-2.2
-- Wagtail 1.13, 2.3-2.8
+- Python 3.6, 3.8
+- Django 1.11, 2.0, 2.2
+- Wagtail 1.13, 2.3, 2.8
 - Django-Flags 4.2+ 
+
+It should be compatible at all intermediate versions, as well.
+If you find that it is not, please [file an issue](issues/new).
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
@@ -43,5 +42,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 long_description = open('README.md', 'r').read()
 
 install_requires = [
-    'wagtail>=1.13,<2.5',
+    'wagtail>=1.13,<2.8',
     'django-flags>=4.2,<5.0'
 ]
 
@@ -40,8 +40,6 @@ setup(
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 long_description = open('README.md', 'r').read()
 
 install_requires = [
-    'wagtail>=1.13,<2.8',
+    'wagtail>=1.13,<2.9',
     'django-flags>=4.2,<5.0'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
@@ -40,7 +41,5 @@ setup(
         'License :: Public Domain',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 skipsdist=True
 envlist=
     lint,
-    py{27,36}-dj{111}-wag{113},
+    py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{22},
     py{36,37}-dj{21}-wag{23,24}
-    py{36,37}-dj{22}-wag{25}
+    py{36,37}-dj{22}-wag{27}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -17,7 +17,6 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailflags.tests.settings
 
 basepython=
-    py27: python2.7
     py36: python3.6
     py37: python3.7
 
@@ -29,6 +28,7 @@ deps=
     wag22: wagtail>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
     wag24: wagtail>=2.4,<2.5
+    wag27: wagtail>=2.7,<2.8
 
 [testenv:lint]
 basepython=python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,11 @@ setenv=
 basepython=
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 
 deps=
     dj111: Django>=1.11,<1.12
+    dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skipsdist=True
 envlist=
     lint,
     py{36}-dj{111}-wag{113},
-    py{36}-dj{111,20}-wag{23},
-    py{36,38}-dj{22}-wag{23,27}
+    py{36}-dj{111,20,22}-wag{23},
+    py{36,38}-dj{22}-wag{28}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -25,7 +25,7 @@ deps=
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4
-    wag27: wagtail>=2.7,<2.8
+    wag28: wagtail>=2.8,<2.9
 
 [testenv:lint]
 basepython=python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,8 @@ skipsdist=True
 envlist=
     lint,
     py{36}-dj{111}-wag{113},
-    py{36}-dj{111,20}-wag{22},
-    py{36,37}-dj{21}-wag{23,24},
-    py{36,37}-dj{22}-wag{27}
+    py{36}-dj{111,20}-wag{23},
+    py{36,37}-dj{22}-wag{23,24}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -27,7 +26,6 @@ deps=
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
-    wag22: wagtail>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
     wag24: wagtail>=2.4,<2.5
     wag27: wagtail>=2.7,<2.8

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=
     lint,
     py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{23},
-    py{36,37}-dj{22}-wag{23,27}
+    py{36,38}-dj{22}-wag{23,27}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -17,13 +17,11 @@ setenv=
 
 basepython=
     py36: python3.6
-    py37: python3.7
     py38: python3.8
 
 deps=
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4
@@ -55,6 +53,6 @@ not_skip=__init__.py
 use_parentheses=1
 known_django=django
 known_wagtail=wagtail
-known_future_library=future,six
+known_future_library=future
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ basepython=
 deps=
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=
     lint,
     py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{22},
-    py{36,37}-dj{21}-wag{23,24}
+    py{36,37}-dj{21}-wag{23,24},
     py{36,37}-dj{22}-wag{27}
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=
     lint,
     py{36}-dj{111}-wag{113},
     py{36}-dj{111,20}-wag{23},
-    py{36,37}-dj{22}-wag{23,24}
+    py{36,37}-dj{22}-wag{23,27}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -27,7 +27,6 @@ deps=
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4
-    wag24: wagtail>=2.4,<2.5
     wag27: wagtail>=2.7,<2.8
 
 [testenv:lint]

--- a/wagtailflags/tests/test_conditions.py
+++ b/wagtailflags/tests/test_conditions.py
@@ -1,5 +1,4 @@
-from django.http import HttpRequest
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
 from flags.conditions import RequiredForCondition
 from wagtailflags.conditions import site_condition
@@ -15,7 +14,8 @@ class SiteConditionTestCase(TestCase):
 
     def setUp(self):
         self.site = Site.objects.get(is_default_site=True)
-        self.request = HttpRequest()
+        self.factory = RequestFactory()
+        self.request = self.factory.get('/')
         self.request.site = self.site
 
     def test_site_valid_string(self):


### PR DESCRIPTION
Support production version of Python 3.6 and latest version of Python 3.8
Support latest version of Wagtail 2.8

Remove Python 2.7 from:
* README.md
* setup.py
* tox.ini
* travis.yml
Add support for Wagtail 2.8 to `tox.ini`, `setup.py`, and `travis.yml`

Testing
$ tox
```
...
  lint: commands succeeded
  py36-dj111-wag113: commands succeeded
  py36-dj111-wag23: commands succeeded
  py36-dj20-wag23: commands succeeded
  py36-dj22-wag23: commands succeeded
  py36-dj22-wag28: commands succeeded
  py38-dj22-wag28: commands succeeded
  congratulations :)
```