### PR TITLE
Hide flag name in condition edit form

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='4.1.0',
+    version='4.1.1',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,

--- a/wagtailflags/forms.py
+++ b/wagtailflags/forms.py
@@ -37,9 +37,10 @@ class FlagStateForm(forms.ModelForm):
         label='Flag',
         required=True,
         disabled=True,
+        widget=forms.HiddenInput(),
     )
     condition = forms.ChoiceField(
-        label='Condition name',
+        label='Condition',
         required=True
     )
     value = forms.CharField(

--- a/wagtailflags/templates/wagtailflags/flags/delete_condition.html
+++ b/wagtailflags/templates/wagtailflags/flags/delete_condition.html
@@ -5,7 +5,6 @@
 {% block content %}
     {% trans "Delete flag condition:" as delete_str %}
     {% include "wagtailadmin/shared/header.html" with title=delete_str subtitle=condition_str %}
-    {% flag_enabled 'WAGTAILFLAGS_ADMIN_BIG_LIST' as big_list_flag %}
 
     <form class="nice-padding" method="POST" action="{% url 'wagtailflags:delete_condition' flag.name condition_pk %}">
       {% csrf_token %}
@@ -13,10 +12,6 @@
       <p>Are you sure you want to delete this flag condition?</p>
       <input type="submit" value="Yes, delete it" class="button serious">
 
-      {% if big_list_flag %}
-        <a href="{% url 'wagtailflags:list' %}#{{ flag.name }}" class="button button-secondary">No, don't delete it</a>
-      {% else %}
-        <a href="{% url 'wagtailflags:flag_index' flag.name %}" class="button button-secondary">No, don't delete it</a>
-      {% endif %}
+      <a href="{% url 'wagtailflags:flag_index' flag.name %}" class="button button-secondary">No, don't delete it</a>
     </form>
 {% endblock %}

--- a/wagtailflags/templates/wagtailflags/flags/edit_condition.html
+++ b/wagtailflags/templates/wagtailflags/flags/edit_condition.html
@@ -4,7 +4,6 @@
 
 {% block content %}
     {% include "wagtailadmin/shared/header.html" with title=flag.name icon="tag" %}
-    {% flag_enabled 'WAGTAILFLAGS_ADMIN_BIG_LIST' as big_list_flag %}
 
     <h2 class="nice-padding">
         {% if form.instance %}Edit {{ form.instance.condition }}{% else %}Create condition{% endif %}
@@ -38,11 +37,7 @@
             </li>
             <li class="actions">
                 <input class="button action-save button-longrunning" type="submit" value="Save condition" />
-                {% if big_list_flag %}
-                    <a class="button bicolor icon icon-cog" href="{% url 'wagtailflags:list' %}#{{ flag.name }}">Back to {{ flag.name }}</a>
-                {% else %}
-                    <a class="button bicolor icon icon-cog" href="{% url 'wagtailflags:flag_index' flag.name %}">Back to {{ flag.name }}</a>
-                {% endif %}
+                <a class="button bicolor icon icon-cog" href="{% url 'wagtailflags:flag_index' flag.name %}">Back to {{ flag.name }}</a>
             </li>
         </ul>
     </form>

--- a/wagtailflags/templates/wagtailflags/flags/edit_condition.html
+++ b/wagtailflags/templates/wagtailflags/flags/edit_condition.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n feature_flags %}
-{% block titletag %}{% if form.instance %}Edit {{ form.instance.condition }}{% else %}Create condition{% endif %}{% endblock %}
+{% block titletag %}{% if form.instance %}Edit {{ form.instance.condition }} condition{% else %}Create condition{% endif %}{% endblock %}
 
 {% block content %}
     {% include "wagtailadmin/shared/header.html" with title=flag.name icon="tag" %}
@@ -18,23 +18,35 @@
     {% endif %}
         {% csrf_token %}
         <ul class="fields">
-            <li class="actions">
-                {% for field in form %}
-                    {% if field.errors %}
-                        <div class="help-block help-critical" style="margin-top:0;">
-                            {{ field.errors }}
+
+            {% for field in form %}
+            <li {% if field.field.required %}class="required"{% endif %}>
+                    {% if not field.is_hidden %}
+                        <div class="field">
+                            {{ field.label_tag }}
+
+                            <div class="field-content">
+                                <div class="input">
+                                    {{ field }}
+                                </div>
+                                {% if field.help_text %}
+                                    <p class="help">{{ field.help_text|safe }}</p>
+                                {% endif %}
+                            </div>
+
+                            {% if field.errors %}
+                                <div class="help-block help-critical" style="margin-top:0;">
+                                    {{ field.errors }}
+                                </div>
+                            {% endif %}
                         </div>
+                    {% else %}
+                        {{ field }}
                     {% endif %}
-                    <label>{{ field.label }}</label>
-                    <div class="field-content">
-                        <div class="input">
-                            {{ field }}
-                            <span></span>
-                        </div>
-                        <p class="help"></p>
-                    </div>
-                {% endfor %}
-            </li>
+
+                </li>
+            {% endfor %}
+
             <li class="actions">
                 <input class="button action-save button-longrunning" type="submit" value="Save condition" />
                 <a class="button bicolor icon icon-cog" href="{% url 'wagtailflags:flag_index' flag.name %}">Back to {{ flag.name }}</a>

--- a/wagtailflags/templates/wagtailflags/index.html
+++ b/wagtailflags/templates/wagtailflags/index.html
@@ -13,36 +13,26 @@
         {% if flags|length == 0 %}
         <p>No flags have been defined.</p>
         {% else %}
-            {% flag_enabled 'WAGTAILFLAGS_ADMIN_BIG_LIST' as big_list_flag %}
-
-            {% if big_list_flag %}
+            <table class="listing">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
                 {% for flag in flags %}
-                    <h2>{{ flag.name }}</h2>
-                    {% include "wagtailflags/includes/flag_index.html" with flag=flag %}
+                    <tr>
+                        <td>
+                            <b><a href="{% url 'wagtailflags:flag_index' flag.name %}">{{ flag.name }}</a></b>
+                        </td>
+                        <td>
+                            {{ flag|state_str }}
+                        </td>
+                    </tr>
                 {% endfor %}
-            {% else %}
-                <table class="listing">
-                    <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                    {% for flag in flags %}
-                        <tr>
-                            <td>
-                                <b><a href="{% url 'wagtailflags:flag_index' flag.name %}">{{ flag.name }}</a></b>
-                            </td>
-                            <td>
-                                {{ flag|state_str }}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            {% endif %}
-
+                </tbody>
+            </table>
         {% endif %}
 
     </div>

--- a/wagtailflags/tests/test_views.py
+++ b/wagtailflags/tests/test_views.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from wagtail.tests.utils import WagtailTestUtils
 

--- a/wagtailflags/tests/test_views.py
+++ b/wagtailflags/tests/test_views.py
@@ -41,15 +41,6 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         self.assertEqual(new_flag_condition.value, 'False')
         self.assertEqual(new_flag_condition.required, False)
 
-    @override_settings(
-        FLAGS={'WAGTAILFLAGS_ADMIN_BIG_LIST': [('boolean', True)]}
-    )
-    def test_flag_create_big_list(self):
-        response = self.client.post(
-            '/admin/flags/create/', {'name': 'NEW_FLAG'}
-        )
-        self.assertRedirects(response, '/admin/flags/#NEW_FLAG')
-
     def test_flag_create_existing(self):
         response = self.client.get('/admin/flags/create/')
         self.assertEqual(response.status_code, 200)
@@ -102,18 +93,6 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         self.assertEqual(condition_query.first().condition, 'boolean')
         self.assertEqual(condition_query.first().value, 'True')
 
-    @override_settings(
-        FLAGS={
-            'WAGTAILFLAGS_ADMIN_BIG_LIST': [('boolean', True)],
-            'FLAG_DISABLED': [],
-        }
-    )
-    def test_enable_flag_big_list(self):
-        response = self.client.get(
-            '/admin/flags/FLAG_DISABLED/', {'enable': ''}
-        )
-        self.assertRedirects(response, '/admin/flags/#FLAG_DISABLED')
-
     def test_enable_flag_with_required_true(self):
         condition_query = FlagState.objects.filter(name='FLAG_DISABLED')
         self.assertEqual(len(condition_query.all()), 0)
@@ -155,17 +134,6 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         self.assertRedirects(response, '/admin/flags/DBONLY_FLAG/')
         self.assertEqual(len(FlagState.objects.all()), 2)
 
-    @override_settings(
-        FLAGS={'WAGTAILFLAGS_ADMIN_BIG_LIST': [('boolean', True)]}
-    )
-    def test_create_flag_condition_big_list(self):
-        params = {
-            'condition': 'path matches',
-            'value': '/db_path',
-        }
-        response = self.client.post('/admin/flags/DBONLY_FLAG/create/', params)
-        self.assertRedirects(response, '/admin/flags/#DBONLY_FLAG')
-
     def test_edit_flag_condition_nonexistent_flag_raises_404(self):
         response = self.client.get('/admin/flags/THIS_FLAG_DOES_NOT_EXIST/99/')
         self.assertEqual(response.status_code, 404)
@@ -196,25 +164,6 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
             'justice'
         )
 
-    @override_settings(
-        FLAGS={'WAGTAILFLAGS_ADMIN_BIG_LIST': [('boolean', True)]}
-    )
-    def test_edit_flag_condition_big_list(self):
-        condition_obj = FlagState.objects.create(
-            name='DBONLY_FLAG',
-            condition='user',
-            value='liberty'
-        )
-        params = {
-            'condition': 'user',
-            'value': 'justice',
-        }
-        response = self.client.post(
-            '/admin/flags/DBONLY_FLAG/{}/'.format(condition_obj.pk),
-            params
-        )
-        self.assertRedirects(response, '/admin/flags/#DBONLY_FLAG')
-
     def test_delete_flag_condition_nonexistent_flag_raises_404(self):
         response = self.client.get(
             '/admin/flags/THIS_FLAG_DOES_NOT_EXIST/99/delete/'
@@ -238,18 +187,3 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         )
         self.assertRedirects(response, '/admin/flags/DBONLY_FLAG/')
         self.assertEqual(len(FlagState.objects.all()), 1)
-
-    @override_settings(
-        FLAGS={'WAGTAILFLAGS_ADMIN_BIG_LIST': [('boolean', True)]}
-    )
-    def test_delete_flag_condition_big_list(self):
-        condition_obj = FlagState.objects.create(
-            name='DBONLY_FLAG',
-            condition='user',
-            value='liberty'
-        )
-        self.assertEqual(len(FlagState.objects.all()), 2)
-        response = self.client.post(
-            '/admin/flags/DBONLY_FLAG/{}/delete/'.format(condition_obj.pk)
-        )
-        self.assertRedirects(response, '/admin/flags/#DBONLY_FLAG')

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -1,9 +1,8 @@
 from django.http import Http404
-from django.shortcuts import get_object_or_404, redirect, render, resolve_url
+from django.shortcuts import get_object_or_404, redirect, render
 
 from flags.models import FlagState
 from flags.sources import get_flags
-from flags.state import flag_enabled
 from flags.templatetags.flags_debug import bool_enabled
 from wagtailflags.forms import FlagStateForm, NewFlagForm
 

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -30,17 +30,9 @@ def create_flag(request):
         )
         if form.is_valid():
             form.save()
-            if flag_enabled('WAGTAILFLAGS_ADMIN_BIG_LIST'):
-                return redirect(
-                    '{flags_list}#{flag_name}'.format(
-                        flags_list=resolve_url('wagtailflags:list'),
-                        flag_name=form.instance.name
-                    )
-                )
-            else:
-                return redirect(
-                    'wagtailflags:flag_index', name=form.instance.name
-                )
+            return redirect(
+                'wagtailflags:flag_index', name=form.instance.name
+            )
     else:
         form = NewFlagForm()
 
@@ -81,16 +73,7 @@ def flag_index(request, name):
             boolean_condition_obj.value = False
 
         boolean_condition_obj.save()
-
-        if flag_enabled('WAGTAILFLAGS_ADMIN_BIG_LIST'):
-            return redirect(
-                '{flags_list}#{flag_name}'.format(
-                    flags_list=resolve_url('wagtailflags:list'),
-                    flag_name=name
-                )
-            )
-        else:
-            return redirect('wagtailflags:flag_index', name=name)
+        return redirect('wagtailflags:flag_index', name=name)
 
     context = {
         'flag': flag,
@@ -115,18 +98,9 @@ def edit_condition(request, name, condition_pk=None):
         )
         if form.is_valid():
             form.save()
-
-            if flag_enabled('WAGTAILFLAGS_ADMIN_BIG_LIST'):
-                return redirect(
-                    '{flags_list}#{flag_name}'.format(
-                        flags_list=resolve_url('wagtailflags:list'),
-                        flag_name=form.instance.name
-                    )
-                )
-            else:
-                return redirect(
-                    'wagtailflags:flag_index', name=form.instance.name
-                )
+            return redirect(
+                'wagtailflags:flag_index', name=name
+            )
 
     else:
         form = FlagStateForm(initial={'name': name}, instance=condition)
@@ -150,16 +124,7 @@ def delete_condition(request, name, condition_pk):
 
     if request.method == 'POST':
         condition.delete()
-
-        if flag_enabled('WAGTAILFLAGS_ADMIN_BIG_LIST'):
-            return redirect(
-                '{flags_list}#{flag_name}'.format(
-                    flags_list=resolve_url('wagtailflags:list'),
-                    flag_name=name
-                )
-            )
-        else:
-            return redirect('wagtailflags:flag_index', name=name)
+        return redirect('wagtailflags:flag_index', name=name)
 
     context = {
         'flag': flag,


### PR DESCRIPTION
This PR changes the `FlagStateForm` to hide the flag name field. The flag name field was already read-only, and was appearing in the Wagtail admin as blank. The field is now hidden.

Before:
![image](https://user-images.githubusercontent.com/10562538/75278011-1deedd00-57d7-11ea-8d74-523d61b608ba.png)

After:
![image](https://user-images.githubusercontent.com/10562538/75277983-0c0d3a00-57d7-11ea-8878-e095b05b8ed7.png)

This PR also removes the deprecated `WAGTAILFLAGS_ADMIN_BIG_LIST` flag for the big-list-of-all-flags-and-conditions admin UI.