### PR TITLE
Remove Wagtail 1.13 and support Django 2.2 imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py36-dj111-wag113
-      python: 3.6
     - env: TOXENV=py36-dj111-wag23
       python: 3.6
     - env: TOXENV=py36-dj20-wag23

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 
 - Python 3.6, 3.8
 - Django 1.11, 2.0, 2.2
-- Wagtail 1.13, 2.3, 2.8
+- Wagtail 2.3, 2.8
 - Django-Flags 4.2+ 
 
 It should be compatible at all intermediate versions, as well.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 long_description = open('README.md', 'r').read()
 
 install_requires = [
-    'wagtail>=1.13,<2.9',
+    'wagtail>=2.2,<2.9',
     'django-flags>=4.2,<5.0'
 ]
 
@@ -21,7 +21,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='4.1.1',
+    version='4.1.2',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,
@@ -35,7 +35,6 @@ setup(
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
-        'Framework :: Wagtail :: 1',
         'Framework :: Wagtail :: 2',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 long_description = open('README.md', 'r').read()
 
 install_requires = [
-    'wagtail>=2.2,<2.9',
+    'wagtail>=2.3,<2.9',
     'django-flags>=4.2,<5.0'
 ]
 
@@ -21,7 +21,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='4.1.2',
+    version='4.2.0',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{111}-wag{113},
     py{36}-dj{111,20,22}-wag{23},
     py{36,38}-dj{22}-wag{28}
 
@@ -24,7 +23,6 @@ deps=
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
-    wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 

--- a/wagtailflags/tests/settings.py
+++ b/wagtailflags/tests/settings.py
@@ -1,10 +1,6 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 import django
-
-import wagtail
 
 
 ALLOWED_HOSTS = ['*']
@@ -36,58 +32,31 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
 )
 
-if wagtail.VERSION >= (2, 0):  # pragma: no cover
-    WAGTAIL_APPS = (
-        'wagtail.contrib.forms',
-        'wagtail.contrib.modeladmin',
-        'wagtail.contrib.settings',
-        'wagtail.tests.testapp',
-        'wagtail.admin',
-        'wagtail.core',
-        'wagtail.documents',
-        'wagtail.images',
-        'wagtail.sites',
-        'wagtail.users',
-    )
+WAGTAIL_APPS = (
+    'wagtail.contrib.forms',
+    'wagtail.contrib.modeladmin',
+    'wagtail.contrib.settings',
+    'wagtail.tests.testapp',
+    'wagtail.admin',
+    'wagtail.core',
+    'wagtail.documents',
+    'wagtail.images',
+    'wagtail.sites',
+    'wagtail.users',
+)
 
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.core.middleware.SiteMiddleware',
-    )
+WAGTAIL_MIDDLEWARE = (
+    'wagtail.core.middleware.SiteMiddleware',
+)
 
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea'
-        },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
-        },
-    }
-else:  # pragma: no cover; fallback for Wagtail < 2.0
-    WAGTAIL_APPS = (
-        'wagtail.contrib.modeladmin',
-        'wagtail.contrib.settings',
-        'wagtail.tests.testapp',
-        'wagtail.wagtailadmin',
-        'wagtail.wagtailcore',
-        'wagtail.wagtaildocs',
-        'wagtail.wagtailforms',
-        'wagtail.wagtailimages',
-        'wagtail.wagtailsites',
-        'wagtail.wagtailusers',
-    )
-
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.wagtailcore.middleware.SiteMiddleware',
-    )
-
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea',
-        },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
-        },
-    }
+WAGTAILADMIN_RICH_TEXT_EDITORS = {
+    'default': {
+        'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea'
+    },
+    'custom': {
+        'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+    },
+}
 
 if django.VERSION >= (1, 10):  # pragma: no cover
     MIDDLEWARE = (

--- a/wagtailflags/tests/test_conditions.py
+++ b/wagtailflags/tests/test_conditions.py
@@ -1,13 +1,9 @@
 from django.test import RequestFactory, TestCase
 
+from wagtail.core.models import Site
+
 from flags.conditions import RequiredForCondition
 from wagtailflags.conditions import site_condition
-
-
-try:
-    from wagtail.core.models import Site
-except ImportError:  # pragma: no cover; fallback for Wagtail < 2.0
-    from wagtail.wagtailcore.models import Site
 
 
 class SiteConditionTestCase(TestCase):

--- a/wagtailflags/tests/urls.py
+++ b/wagtailflags/tests/urls.py
@@ -1,12 +1,13 @@
-from django.conf.urls import include, url
+from wagtail.admin import urls as wagtailadmin_urls
 
 
-try:  # pragma: no cover; Wagtail >= 2.0
-    from wagtail.admin import urls as wagtailadmin_urls
-except ImportError:  # pragma: no cover; fallback for Wagtail < 2.0
-    from wagtail.wagtailadmin import urls as wagtailadmin_urls
+try:  # pragma: no cover; >= 2.0
+    from django.urls import include, re_path
+except ImportError:  # pragma: no cover; fallback for Django < 2.0
+    from django.conf.urls import include
+    from django.conf.urls import url as re_path
 
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
+    re_path(r'^admin/', include(wagtailadmin_urls)),
 ]

--- a/wagtailflags/wagtail_hooks.py
+++ b/wagtailflags/wagtail_hooks.py
@@ -1,22 +1,19 @@
 import django
-from django.conf.urls import include, url
 from django.templatetags.static import static
 from django.utils.html import format_html
+
+from wagtail.admin.menu import MenuItem
+from wagtail.core import hooks
 
 from wagtailflags import views
 
 
 try:  # pragma: no cover; >= 2.0
-    from django.urls import reverse
+    from django.urls import include, reverse, re_path
 except ImportError:  # pragma: no cover; fallback for Django < 2.0
+    from django.conf.urls import include
+    from django.conf.urls import url as re_path
     from django.core.urlresolvers import reverse
-
-try:  # pragma: no cover; Wagtail >= 2.0
-    from wagtail.admin.menu import MenuItem
-    from wagtail.core import hooks
-except ImportError:  # pragma: no cover; fallback for Wagtail < 2.0
-    from wagtail.wagtailadmin.menu import MenuItem
-    from wagtail.wagtailcore import hooks
 
 
 @hooks.register('register_settings_menu_item')
@@ -28,20 +25,20 @@ def register_flags_menu():
 @hooks.register('register_admin_urls')
 def register_flag_admin_urls():
     flagpatterns = [
-        url(r'^$', views.index, name='list'),
-        url(r'^create/$', views.create_flag, name='create_flag'),
-        url(r'^(?P<name>[\w\-]+)/$', views.flag_index, name='flag_index'),
-        url(
+        re_path(r'^$', views.index, name='list'),
+        re_path(r'^create/$', views.create_flag, name='create_flag'),
+        re_path(r'^(?P<name>[\w\-]+)/$', views.flag_index, name='flag_index'),
+        re_path(
             r'^(?P<name>[\w\-]+)/create/$',
             views.edit_condition,
             name='create_condition'
         ),
-        url(
+        re_path(
             r'^(?P<name>[\w\-]+)/(?P<condition_pk>\d+)/$',
             views.edit_condition,
             name='edit_condition'
         ),
-        url(
+        re_path(
             r'^(?P<name>[\w\-]+)/(?P<condition_pk>\d+)/delete/$',
             views.delete_condition,
             name='delete_condition'
@@ -50,14 +47,14 @@ def register_flag_admin_urls():
 
     if django.VERSION >= (1, 10):  # pragma: no cover
         urlpatterns = [
-            url(r'^flags/',
-                include((flagpatterns, 'wagtailflags'),
-                        namespace='wagtailflags'))
+            re_path(r'^flags/',
+                    include((flagpatterns, 'wagtailflags'),
+                            namespace='wagtailflags'))
         ]
     else:  # pragma: no cover; fallback for Django < 1.10
         urlpatterns = [
-            url(r'^flags/',
-                include((flagpatterns, 'wagtailflags', 'wagtailflags')))
+            re_path(r'^flags/',
+                    include((flagpatterns, 'wagtailflags', 'wagtailflags')))
         ]
 
     return urlpatterns


### PR DESCRIPTION
## Removed
Support for Wagtail 1.13 in tox and travis
`from __future__ import absolute_import, unicode_literals`

## Added
Support for Django 2.2 imports in tests