### PR TITLE
Fix lint errors due to using isort 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "wagtail~=2.0",
+    "wagtail>=2.3,<2.10",
     "django-flags>=4.2,<5.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ setup(
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
     license="CC0",
-    version="4.2.2",
+    version="4.2.1",
     include_package_data=True,
     packages=find_packages(),
-    python_requires=">=3",
+    python_requires=">=3.6",
     install_requires=install_requires,
     extras_require={"testing": testing_extras},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import find_packages, setup
 
-install_requires = ["wagtail>=2.3,<2.10", "django-flags>=4.2,<5.0"]
+install_requires = [
+    "wagtail~=2.0",
+    "django-flags>=4.2,<5.0",
+]
 
 testing_extras = ["coverage>=3.7.0"]
 
@@ -13,9 +16,10 @@ setup(
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
     license="CC0",
-    version="4.2.1",
+    version="4.2.2",
     include_package_data=True,
     packages=find_packages(),
+    python_requires=">=3",
     install_requires=install_requires,
     extras_require={"testing": testing_extras},
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps=
 commands=
     black --check wagtailflags setup.py
     flake8 .
-    isort --check-only --diff --recursive wagtailflags
+    isort --check-only --diff wagtailflags
 
 [flake8]
 ignore=E731,W503,W504
@@ -50,7 +50,6 @@ lines_after_imports=2
 include_trailing_comma=1
 multi_line_output=3
 skip=.tox,migrations
-not_skip=__init__.py
 use_parentheses=1
 known_django=django
 known_wagtail=wagtail

--- a/wagtailflags/tests/test_conditions.py
+++ b/wagtailflags/tests/test_conditions.py
@@ -3,6 +3,7 @@ from django.test import RequestFactory, TestCase
 from wagtail.core.models import Site
 
 from flags.conditions import RequiredForCondition
+
 from wagtailflags.conditions import site_condition
 
 

--- a/wagtailflags/tests/test_templatetags_wagtailflags_admin.py
+++ b/wagtailflags/tests/test_templatetags_wagtailflags_admin.py
@@ -1,6 +1,7 @@
 from django.test import TestCase, override_settings
 
 from flags.sources import get_flags
+
 from wagtailflags.templatetags.wagtailflags_admin import disablable, enablable
 
 

--- a/wagtailflags/tests/urls.py
+++ b/wagtailflags/tests/urls.py
@@ -4,8 +4,7 @@ from wagtail.admin import urls as wagtailadmin_urls
 try:  # pragma: no cover; >= 2.0
     from django.urls import include, re_path
 except ImportError:  # pragma: no cover; fallback for Django < 2.0
-    from django.conf.urls import include
-    from django.conf.urls import url as re_path
+    from django.conf.urls import include, url as re_path
 
 
 urlpatterns = [

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from flags.models import FlagState
 from flags.sources import get_flags
 from flags.templatetags.flags_debug import bool_enabled
+
 from wagtailflags.forms import FlagStateForm, NewFlagForm
 
 

--- a/wagtailflags/wagtail_hooks.py
+++ b/wagtailflags/wagtail_hooks.py
@@ -9,10 +9,9 @@ from wagtailflags import views
 
 
 try:  # pragma: no cover; >= 2.0
-    from django.urls import include, reverse, re_path
+    from django.urls import include, re_path, reverse
 except ImportError:  # pragma: no cover; fallback for Django < 2.0
-    from django.conf.urls import include
-    from django.conf.urls import url as re_path
+    from django.conf.urls import include, url as re_path
     from django.core.urlresolvers import reverse
 
 


### PR DESCRIPTION
Removed `not_skip` and `recursive` from `tox.ini` to fix
TypeError: __init__() got an unexpected keyword argument 'not_skip'

* recursive
Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.

* not_skip
In an earlier version isort had a default skip of __init__.py. To get around that many projects wanted a way to not skip __init__.py or any other files that were automatically skipped in the future by isort. isort no longer has any default skips, so if the value here is __init__.py you can simply remove the setting.

https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/