### PR TITLE
Inherit the FlagStateForm from Django Flags

### DIFF
--- a/wagtailflags/forms.py
+++ b/wagtailflags/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from flags.conditions import get_conditions
+from flags.forms import FlagStateForm as DjangoFlagsFlagStateForm
 from flags.models import FlagState
 from flags.sources import get_flags
 
@@ -29,27 +29,10 @@ class NewFlagForm(forms.ModelForm):
         fields = ("name",)
 
 
-class FlagStateForm(forms.ModelForm):
+class FlagStateForm(DjangoFlagsFlagStateForm):
     name = forms.CharField(
         label="Flag", required=True, disabled=True, widget=forms.HiddenInput(),
     )
-    condition = forms.ChoiceField(label="Condition", required=True)
-    value = forms.CharField(label="Expected value", required=True)
-    required = forms.BooleanField(
-        label="Required",
-        required=False,
-        help_text=(
-            'All conditions marked "required" must be met to enable '
-            "the flag"
-        ),
-    )
-
-    def __init__(self, *args, **kwargs):
-        super(FlagStateForm, self).__init__(*args, **kwargs)
-
-        self.fields["condition"].choices = [
-            (c, c) for c in sorted(get_conditions()) if c != "boolean"
-        ]
 
     class Meta:
         model = FlagState

--- a/wagtailflags/templates/wagtailflags/flags/edit_condition.html
+++ b/wagtailflags/templates/wagtailflags/flags/edit_condition.html
@@ -9,8 +9,6 @@
         {% if form.instance %}Edit {{ form.instance.condition }}{% else %}Create condition{% endif %}
     </h2>
 
-    {{ form.errors }}
-
     {% if condition_pk %}
     <form class="nice-padding" method="POST" action="{% url 'wagtailflags:edit_condition' flag.name condition_pk %}">
     {% else %}


### PR DESCRIPTION
This change will use the `FlagStateForm` from Django-Flags as the superclass for the Wagtail-Flags' `FlagStateForm`. 

This enables Wagtail-Flags to use the Django-Flags condition validators introduced in Django-Flags 5.0.

In Wagtail-Flags, this will look like this:

![image](https://user-images.githubusercontent.com/10562538/90548602-307d1a00-e15b-11ea-96ca-3973a7b84658.png)

When a value is entered that a condition's validator does not accept.