### PR TITLE
Fix add flag link in Wagtail 2.10.

### DIFF
--- a/wagtailflags/templates/wagtailflags/includes/header.html
+++ b/wagtailflags/templates/wagtailflags/includes/header.html
@@ -4,6 +4,10 @@
   <li>{{ title }}</li>
 </ul>
 {% include "wagtailadmin/shared/header.html" with title=title icon=icon %}
+{% elif wagtail_header_action %}
+{# Wagtail 2.10 changes "add_*" in the shared admin header to "action_*" #}
+{% url 'wagtailflags:create_flag' as add_link %}
+{% include "wagtailadmin/shared/header.html" with title=title action_icon=icon action_text='Add flag' action_url=add_link %}
 {% else %}
 {% include "wagtailadmin/shared/header.html" with title=title icon=icon add_text='Add flag' add_link='wagtailflags:create_flag' %}
 {% endif %}

--- a/wagtailflags/tests/test_conditions.py
+++ b/wagtailflags/tests/test_conditions.py
@@ -13,10 +13,10 @@ class SiteConditionTestCase(TestCase):
         self.site = Site.objects.get(is_default_site=True)
         self.factory = RequestFactory()
         self.request = self.factory.get("/")
-        if wagtail.VERSION < (2, 9):
-            self.request.site = self.site
-        else:
+        if wagtail.VERSION >= (2, 9):  # pragma: no cover
             Site.find_for_request(self.request)
+        else:  # pragma: no cover
+            self.request.site = self.site
 
     def test_site_valid_string(self):
         self.assertTrue(site_condition("localhost:80", request=self.request))

--- a/wagtailflags/tests/test_views.py
+++ b/wagtailflags/tests/test_views.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+import wagtail
 from wagtail.tests.utils import WagtailTestUtils
 
 from flags.models import FlagState
@@ -25,6 +26,14 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         self.assertContains(response, "DBONLY_FLAG")
         self.assertContains(response, "<b>enabled</b> when")
         self.assertContains(response, "<b>enabled</b> for")
+
+    def test_flags_index_wagtail210_header_action(self):
+        response = self.client.get("/admin/flags/")
+
+        if wagtail.VERSION >= (2, 10):  # pragma: no cover
+            self.assertTrue(response.context["wagtail_header_action"])
+        else:  # pragma: no cover
+            self.assertFalse(response.context["wagtail_header_action"])
 
     def test_flag_create(self):
         response = self.client.get("/admin/flags/create/")

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -1,6 +1,8 @@
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 
+import wagtail
+
 from flags.models import FlagState
 from flags.sources import get_flags
 from flags.templatetags.flags_debug import bool_enabled
@@ -11,6 +13,8 @@ from wagtailflags.forms import FlagStateForm, NewFlagForm
 def index(request):
     context = {
         "flags": sorted(get_flags().values(), key=lambda x: x.name),
+        # Wagtail 2.10 changes "add_*" in the shared admin header to "action_*"
+        "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
     }
     return render(request, "wagtailflags/index.html", context)
 


### PR DESCRIPTION
Wagtail 2.10 [changes the "add_*" variables](https://github.com/wagtail/wagtail/commit/7565248438337da81d2d3be5f279d5724db0fd7e) for the button link that appears in the top right of the header to "action_\*". This change supports that while remaining backwards compatible with "add_*".