### PR TITLE
Update the build status badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wagtail-Flags
 
-[![Build Status](https://travis-ci.org/cfpb/wagtail-flags.svg?branch=master)](https://travis-ci.org/cfpb/wagtail-flags)
+[![Build Status](https://github.com/cfpb/wagtail-flags/workflows/test/badge.svg)](https://github.com/cfpb/wagtail-flags/actions?query=workflow%3Atest)
 [![Coverage Status](https://coveralls.io/repos/github/cfpb/wagtail-flags/badge.svg?branch=master)](https://coveralls.io/github/cfpb/wagtail-flags?branch=master)
 
 Feature flags allow you to toggle functionality based on configurable conditions. 

--- a/wagtailflags/tests/test_views.py
+++ b/wagtailflags/tests/test_views.py
@@ -139,7 +139,7 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
 
     def test_edit_flag_condition(self):
         condition_obj = FlagState.objects.create(
-            name="DBONLY_FLAG", condition="user", value="liberty"
+            name="DBONLY_FLAG", condition="boolean", value="true"
         )
         response = self.client.get(
             "/admin/flags/DBONLY_FLAG/{}/".format(condition_obj.pk)
@@ -147,8 +147,8 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         params = {
-            "condition": "user",
-            "value": "justice",
+            "condition": "boolean",
+            "value": "true",
         }
 
         response = self.client.post(
@@ -156,7 +156,7 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         )
         self.assertRedirects(response, "/admin/flags/DBONLY_FLAG/")
         self.assertEqual(
-            FlagState.objects.get(pk=condition_obj.pk).value, "justice"
+            FlagState.objects.get(pk=condition_obj.pk).value, "true"
         )
 
     def test_delete_flag_condition_nonexistent_flag_raises_404(self):
@@ -167,7 +167,7 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
 
     def test_delete_flag_condition(self):
         condition_obj = FlagState.objects.create(
-            name="DBONLY_FLAG", condition="user", value="liberty"
+            name="DBONLY_FLAG", condition="boolean", value="true"
         )
         self.assertEqual(len(FlagState.objects.all()), 2)
         response = self.client.get(


### PR DESCRIPTION
We switched from Travis to GitHub Actions for Wagtail-Flags. This change updates the build status badge in the README to use the `test` action status.