### PR TITLE
Support LTS + Current versions of Wagtail and Django

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,18 +32,21 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-dj22-wag23
+            - py36-dj22-wag27
             - py36-dj22-wag210
             - py36-dj31-wag210
+            - py38-dj22-wag27
             - py38-dj22-wag210
             - py38-dj31-wag210
         include:
-          - toxenv: py36-dj22-wag23
+          - toxenv: py36-dj22-wag27
             python-version: 3.6
           - toxenv: py36-dj22-wag210
             python-version: 3.6
           - toxenv: py36-dj31-wag210
             python-version: 3.6
+          - toxenv: py38-dj22-wag27
+            python-version: 3.8
           - toxenv: py38-dj22-wag210
             python-version: 3.8
           - toxenv: py38-dj31-wag210

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 ## Dependencies
 
 - Python 3.6+
-- Django 2.2, 3.1
-- Django-Flags 4.2+ 
-- Wagtail 2.3, 2.9, 2.10
+- Django 2.2 (LTS), 3.1 (current)
+- Django-Flags 4.2 
+- Wagtail 2.7 (LTS), 2.10 (current)
 
 It should be compatible at all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-flags/issues/new).

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "wagtail>=2.3,<2.11",
+    "wagtail>=2.7,<2.11",
     "django-flags>=4.2,<5.1",
 ]
 
@@ -16,7 +16,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     license="CC0",
-    version="4.2.3",
+    version="5.0.0",
     include_package_data=True,
     packages=find_packages(),
     python_requires=">=3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{22}-wag{23,29},
-    py{36,38}-dj{22,31}-wag{210}
+    py{36,38}-dj{22,31}-wag{27,210}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -21,8 +20,7 @@ basepython=
 deps=
     dj22:  Django>=2.2,<2.3
     dj31:  Django>=3.1,<3.2
-    wag23: wagtail>=2.3,<2.4
-    wag29: wagtail>=2.9,<2.10
+    wag27: wagtail>=2.7,<2.8
     wag210: wagtail>=2.10,<2.11
 
 [testenv:lint]

--- a/wagtailflags/conditions.py
+++ b/wagtailflags/conditions.py
@@ -6,8 +6,8 @@ from flags.conditions import RequiredForCondition, register
 
 @register("site")
 def site_condition(site_str, request=None, **kwargs):
-    """ Does the requests's Wagtail Site match the given site?
-    site_str should be 'hostname:port', or 'hostname [default]'. """
+    """Does the requests's Wagtail Site match the given site?
+    site_str should be 'hostname:port', or 'hostname [default]'."""
     if request is None:
         raise RequiredForCondition(
             "request is required for condition " "'site'"

--- a/wagtailflags/forms.py
+++ b/wagtailflags/forms.py
@@ -31,7 +31,10 @@ class NewFlagForm(forms.ModelForm):
 
 class FlagStateForm(DjangoFlagsFlagStateForm):
     name = forms.CharField(
-        label="Flag", required=True, disabled=True, widget=forms.HiddenInput(),
+        label="Flag",
+        required=True,
+        disabled=True,
+        widget=forms.HiddenInput(),
     )
 
     class Meta:

--- a/wagtailflags/tests/settings.py
+++ b/wagtailflags/tests/settings.py
@@ -64,7 +64,10 @@ INSTALLED_APPS = (
         "taggit",
     )
     + WAGTAIL_APPS
-    + ("flags", "wagtailflags",)
+    + (
+        "flags",
+        "wagtailflags",
+    )
 )
 
 STATIC_ROOT = "/tmp/static/"

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -16,9 +16,9 @@ def index(request):
 
 
 def create_flag(request):
-    """ Create a new flag.
+    """Create a new flag.
     This will add a FlagState object with a custom name and a boolean: False
-    condition """
+    condition"""
     if request.method == "POST":
         form = NewFlagForm(
             request.POST,


### PR DESCRIPTION
This change updates our supported version ranges to the LTS releases of Wagtail (2.7) and Django (2.2) and the current releases of Wagtail (2.10) and Django (3.1).