### PR TITLE
Make database-only flags deletable in Wagtail 2.10+

### DIFF
--- a/wagtailflags/templates/wagtailflags/flags/delete_flag.html
+++ b/wagtailflags/templates/wagtailflags/flags/delete_flag.html
@@ -1,0 +1,17 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n feature_flags %}
+{% block titletag %}{% trans "Delete" as delete_str %} {{ flag.name }}{% endblock %}
+
+{% block content %}
+    {% trans "Delete flag:" as delete_str %}
+    {% include "wagtailadmin/shared/header.html" with title=delete_str subtitle=flag.name %}
+
+    <form class="nice-padding" method="POST" action="{% url 'wagtailflags:delete_flag' flag.name %}">
+      {% csrf_token %}
+
+      <p>Are you sure you want to delete this flag and all its conditions?</p>
+      <input type="submit" value="Yes, delete it" class="button serious">
+
+      <a href="{% url 'wagtailflags:flag_index' flag.name %}" class="button button-secondary">No, don't delete it</a>
+    </form>
+{% endblock %}

--- a/wagtailflags/templates/wagtailflags/includes/header.html
+++ b/wagtailflags/templates/wagtailflags/includes/header.html
@@ -7,7 +7,7 @@
   {% if flag|deletable %}
     {% if wagtail_header_action %}
       {% url 'wagtailflags:delete_flag' flag.name as delete_link %}
-      {# Wagtail 2.10 changes "add_*" in the shared admin header to "action_*" #}
+      {# Wagtail 2.10 adds "action_*", which we need to enable the "Delete flag" button in the header. #}
       {% include "wagtailadmin/shared/header.html" with title=title action_icon="bin" action_text='Delete flag' action_url=delete_link %}
     {% endif %}
   {% else %}

--- a/wagtailflags/templates/wagtailflags/includes/header.html
+++ b/wagtailflags/templates/wagtailflags/includes/header.html
@@ -1,13 +1,22 @@
+{% load wagtailflags_admin %}
 {% if flag %}
-<ul class="breadcrumb flags-breadcrumb">
-  <li><a href="{% url 'wagtailflags:list' %}">Flags</a></li>
-  <li>{{ title }}</li>
-</ul>
-{% include "wagtailadmin/shared/header.html" with title=title icon=icon %}
+  <ul class="breadcrumb flags-breadcrumb">
+    <li><a href="{% url 'wagtailflags:list' %}">Flags</a></li>
+    <li>{{ title }}</li>
+  </ul>
+  {% if flag|deletable %}
+    {% if wagtail_header_action %}
+      {% url 'wagtailflags:delete_flag' flag.name as delete_link %}
+      {# Wagtail 2.10 changes "add_*" in the shared admin header to "action_*" #}
+      {% include "wagtailadmin/shared/header.html" with title=title action_icon="bin" action_text='Delete flag' action_url=delete_link %}
+    {% endif %}
+  {% else %}
+    {% include "wagtailadmin/shared/header.html" with title=title icon=icon %}
+  {% endif %}
 {% elif wagtail_header_action %}
-{# Wagtail 2.10 changes "add_*" in the shared admin header to "action_*" #}
-{% url 'wagtailflags:create_flag' as add_link %}
-{% include "wagtailadmin/shared/header.html" with title=title action_icon=icon action_text='Add flag' action_url=add_link %}
+  {# Wagtail 2.10 changes "add_*" in the shared admin header to "action_*" #}
+  {% url 'wagtailflags:create_flag' as add_link %}
+  {% include "wagtailadmin/shared/header.html" with title=title action_icon=icon action_text='Add flag' action_url=add_link %}
 {% else %}
-{% include "wagtailadmin/shared/header.html" with title=title icon=icon add_text='Add flag' add_link='wagtailflags:create_flag' %}
+  {% include "wagtailadmin/shared/header.html" with title=title icon=icon add_text='Add flag' add_link='wagtailflags:create_flag' %}
 {% endif %}

--- a/wagtailflags/templatetags/wagtailflags_admin.py
+++ b/wagtailflags/templatetags/wagtailflags_admin.py
@@ -1,5 +1,6 @@
 from django import template
 
+from flags.sources import DatabaseCondition
 from flags.templatetags.flags_debug import bool_enabled
 
 
@@ -9,8 +10,10 @@ register = template.Library()
 @register.filter
 def enablable(flag):
     """Return true if a flag is enablable by Wagtail-Flags.
+
     A flag is enablable by Wagtail-Flags if it has a required boolean
-    condition and that boolean condition is False."""
+    condition and that boolean condition is False.
+    """
     return not any(
         c.required for c in flag.conditions if c.condition == "boolean"
     ) and not bool_enabled(flag)
@@ -18,7 +21,8 @@ def enablable(flag):
 
 @register.filter
 def disablable(flag):
-    """Return true if a flag is disabable by Wagtail-Flags.
+    """Return true if a flag is disablable by Wagtail-Flags.
+
     A flag is disablable by Wagtail-Flags if it has a required boolean
     condition and that boolean condition is True."""
     return not any(
@@ -29,8 +33,9 @@ def disablable(flag):
 @register.filter
 def deletable(flag):
     """Return true if a flag is deletable by Wagtail-Flags.
-    A flag is deletable by Wagtal-Flags if it is database-only, which means it
-    will have a non-None "obj" attribute."""
+
+    A flag is deletable by Wagtail-Flags if it is database-only, which means it
+    will have any conditions that are not DatabaseCondition."""
     return not any(
-        c for c in flag.conditions if getattr(c, "obj", None) is None
+        c for c in flag.conditions if not isinstance(c, DatabaseCondition)
     )

--- a/wagtailflags/templatetags/wagtailflags_admin.py
+++ b/wagtailflags/templatetags/wagtailflags_admin.py
@@ -8,6 +8,9 @@ register = template.Library()
 
 @register.filter
 def enablable(flag):
+    """Return true if a flag is enablable by Wagtail-Flags.
+    A flag is enablable by Wagtail-Flags if it has a required boolean
+    condition and that boolean condition is False."""
     return not any(
         c.required for c in flag.conditions if c.condition == "boolean"
     ) and not bool_enabled(flag)
@@ -15,6 +18,19 @@ def enablable(flag):
 
 @register.filter
 def disablable(flag):
+    """Return true if a flag is disabable by Wagtail-Flags.
+    A flag is disablable by Wagtail-Flags if it has a required boolean
+    condition and that boolean condition is True."""
     return not any(
         c.required for c in flag.conditions if c.condition == "boolean"
     ) and bool_enabled(flag)
+
+
+@register.filter
+def deletable(flag):
+    """Return true if a flag is deletable by Wagtail-Flags.
+    A flag is deletable by Wagtal-Flags if it is database-only, which means it
+    will have a non-None "obj" attribute."""
+    return not any(
+        c for c in flag.conditions if getattr(c, "obj", None) is None
+    )

--- a/wagtailflags/templatetags/wagtailflags_admin.py
+++ b/wagtailflags/templatetags/wagtailflags_admin.py
@@ -36,6 +36,6 @@ def deletable(flag):
 
     A flag is deletable by Wagtail-Flags if it is database-only, which means it
     will have any conditions that are not DatabaseCondition."""
-    return not any(
+    return (len(flag.conditions) > 0) and not any(
         c for c in flag.conditions if not isinstance(c, DatabaseCondition)
     )

--- a/wagtailflags/templatetags/wagtailflags_admin.py
+++ b/wagtailflags/templatetags/wagtailflags_admin.py
@@ -24,7 +24,8 @@ def disablable(flag):
     """Return true if a flag is disablable by Wagtail-Flags.
 
     A flag is disablable by Wagtail-Flags if it has a required boolean
-    condition and that boolean condition is True."""
+    condition and that boolean condition is True.
+    """
     return not any(
         c.required for c in flag.conditions if c.condition == "boolean"
     ) and bool_enabled(flag)
@@ -34,8 +35,9 @@ def disablable(flag):
 def deletable(flag):
     """Return true if a flag is deletable by Wagtail-Flags.
 
-    A flag is deletable by Wagtail-Flags if it is database-only, which means it
-    will have any conditions that are not DatabaseCondition."""
-    return (len(flag.conditions) > 0) and not any(
-        c for c in flag.conditions if not isinstance(c, DatabaseCondition)
+    A flag is deletable by Wagtail-Flags if it is database-only, which means
+    all of its conditions are type DatabaseCondition.
+    """
+    return flag.conditions and all(
+        isinstance(c, DatabaseCondition) for c in flag.conditions
     )

--- a/wagtailflags/tests/test_templatetags_wagtailflags_admin.py
+++ b/wagtailflags/tests/test_templatetags_wagtailflags_admin.py
@@ -1,8 +1,13 @@
 from django.test import TestCase, override_settings
 
+from flags.models import FlagState
 from flags.sources import get_flags
 
-from wagtailflags.templatetags.wagtailflags_admin import disablable, enablable
+from wagtailflags.templatetags.wagtailflags_admin import (
+    deletable,
+    disablable,
+    enablable,
+)
 
 
 class TestWagtailFlagsAdminTemplateTags(TestCase):
@@ -35,3 +40,13 @@ class TestWagtailFlagsAdminTemplateTags(TestCase):
     def test_disablable_enabled_required(self):
         flag = get_flags().get("MYFLAG")
         self.assertFalse(disablable(flag))
+
+    @override_settings(FLAGS={"MYFLAG": [("boolean", False)]})
+    def test_deletable(self):
+        FlagState.objects.create(
+            name="DBFLAG",
+            condition="boolean",
+            value="True",
+        )
+        self.assertFalse(deletable(get_flags().get("MYFLAG")))
+        self.assertTrue(deletable(get_flags().get("DBFLAG")))

--- a/wagtailflags/tests/test_templatetags_wagtailflags_admin.py
+++ b/wagtailflags/tests/test_templatetags_wagtailflags_admin.py
@@ -41,7 +41,7 @@ class TestWagtailFlagsAdminTemplateTags(TestCase):
         flag = get_flags().get("MYFLAG")
         self.assertFalse(disablable(flag))
 
-    @override_settings(FLAGS={"MYFLAG": [("boolean", False)]})
+    @override_settings(FLAGS={"MYFLAG": [("boolean", False)], "EMPTYFLAG": []})
     def test_deletable(self):
         FlagState.objects.create(
             name="DBFLAG",
@@ -49,4 +49,5 @@ class TestWagtailFlagsAdminTemplateTags(TestCase):
             value="True",
         )
         self.assertFalse(deletable(get_flags().get("MYFLAG")))
+        self.assertFalse(deletable(get_flags().get("EMPTYFLAG")))
         self.assertTrue(deletable(get_flags().get("DBFLAG")))

--- a/wagtailflags/tests/test_views.py
+++ b/wagtailflags/tests/test_views.py
@@ -66,7 +66,7 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
 
     def test_flag_delete_not_deletable(self):
         response = self.client.get("/admin/flags/FLAG_ENABLED/delete/")
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 403)
 
     def test_flag_index_nonexistent_flag_raises_404(self):
         response = self.client.get("/admin/flags/THIS_FLAG_DOES_NOT_EXIST/")

--- a/wagtailflags/tests/test_views.py
+++ b/wagtailflags/tests/test_views.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 
-import wagtail
 from wagtail.tests.utils import WagtailTestUtils
 
 from flags.models import FlagState
@@ -27,14 +26,6 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         self.assertContains(response, "<b>enabled</b> when")
         self.assertContains(response, "<b>enabled</b> for")
 
-    def test_flags_index_wagtail210_header_action(self):
-        response = self.client.get("/admin/flags/")
-
-        if wagtail.VERSION >= (2, 10):  # pragma: no cover
-            self.assertTrue(response.context["wagtail_header_action"])
-        else:  # pragma: no cover
-            self.assertFalse(response.context["wagtail_header_action"])
-
     def test_flag_create(self):
         response = self.client.get("/admin/flags/create/")
         self.assertEqual(response.status_code, 200)
@@ -57,6 +48,25 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
             "/admin/flags/create/", {"name": "DBONLY_FLAG"}
         )
         self.assertContains(response, "Flag named DBONLY_FLAG already exists")
+
+    def test_flag_delete(self):
+        response = self.client.get("/admin/flags/DBONLY_FLAG/delete/")
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.post("/admin/flags/DBONLY_FLAG/delete/")
+
+        self.assertRedirects(response, "/admin/flags/")
+        self.assertEqual(FlagState.objects.count(), 0)
+
+    def test_flag_delete_nonexistent(self):
+        response = self.client.get(
+            "/admin/flags/THIS_FLAG_DOES_NOT_EXIST/delete/"
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_flag_delete_not_deletable(self):
+        response = self.client.get("/admin/flags/FLAG_ENABLED/delete/")
+        self.assertEqual(response.status_code, 405)
 
     def test_flag_index_nonexistent_flag_raises_404(self):
         response = self.client.get("/admin/flags/THIS_FLAG_DOES_NOT_EXIST/")

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -1,4 +1,4 @@
-from django.http import Http404
+from django.http import Http404, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, redirect, render
 
 import wagtail
@@ -9,6 +9,7 @@ from flags.templatetags.flags_debug import bool_enabled
 
 from wagtailflags.forms import FlagStateForm, NewFlagForm
 from wagtailflags.signals import flag_disabled, flag_enabled
+from wagtailflags.templatetags.wagtailflags_admin import deletable
 
 
 def index(request):
@@ -41,6 +42,28 @@ def create_flag(request):
 
     context = dict(form=form)
     return render(request, "wagtailflags/flags/create_flag.html", context)
+
+
+def delete_flag(request, name):
+    """ Delete a database flag. """
+    flag = get_flags().get(name)
+
+    if not flag:
+        raise Http404
+
+    if not deletable(flag):
+        return HttpResponseNotAllowed(request.method)
+
+    if request.method == "POST":
+        for condition in flag.conditions:
+            condition.obj.delete()
+        return redirect("wagtailflags:list")
+
+    context = {
+        "flag": flag,
+        "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
+    }
+    return render(request, "wagtailflags/flags/delete_flag.html", context)
 
 
 def flag_index(request, name):
@@ -81,6 +104,7 @@ def flag_index(request, name):
 
     context = {
         "flag": flag,
+        "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
     }
     return render(request, "wagtailflags/flags/flag_index.html", context)
 

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -52,7 +52,7 @@ def delete_flag(request, name):
         raise Http404
 
     if not deletable(flag):
-        return HttpResponseForbidden(flag)
+        return HttpResponseForbidden(name)
 
     if request.method == "POST":
         FlagState.objects.filter(name=name).delete()

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -1,4 +1,4 @@
-from django.http import Http404, HttpResponseNotAllowed
+from django.http import Http404, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 
 import wagtail
@@ -52,7 +52,7 @@ def delete_flag(request, name):
         raise Http404
 
     if not deletable(flag):
-        return HttpResponseNotAllowed(request.method)
+        return HttpResponseForbidden(request.method)
 
     if request.method == "POST":
         for condition in flag.conditions:

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -55,8 +55,7 @@ def delete_flag(request, name):
         return HttpResponseForbidden(request.method)
 
     if request.method == "POST":
-        for condition in flag.conditions:
-            condition.obj.delete()
+        FlagState.objects.filter(name=name).delete()
         return redirect("wagtailflags:list")
 
     context = {

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -52,7 +52,7 @@ def delete_flag(request, name):
         raise Http404
 
     if not deletable(flag):
-        return HttpResponseForbidden(request.method)
+        return HttpResponseForbidden(flag)
 
     if request.method == "POST":
         FlagState.objects.filter(name=name).delete()

--- a/wagtailflags/wagtail_hooks.py
+++ b/wagtailflags/wagtail_hooks.py
@@ -32,6 +32,11 @@ def register_flag_admin_urls():
         re_path(r"^create/$", views.create_flag, name="create_flag"),
         re_path(r"^(?P<name>[\w\-]+)/$", views.flag_index, name="flag_index"),
         re_path(
+            r"^(?P<name>[\w\-]+)/delete/$",
+            views.delete_flag,
+            name="delete_flag",
+        ),
+        re_path(
             r"^(?P<name>[\w\-]+)/create/$",
             views.edit_condition,
             name="create_condition",


### PR DESCRIPTION
This change makes it possible to delete database-only flags from within the admin in Wagtail 2.10 and above.

Feature flags should be ephemeral, and prior to this change it was not possible to delete database flags added with the "Add flag" button in the Wagtail admin without using the Django admin.

This change adds a button to the top of flag index page to delete the flag if it only exists as conditions in the database.

Fixes #41 