### PR TITLE
Add signals for when "Enable" and "Disable" buttons are pressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 - [Installation](#installation)
 - [Usage](#usage)
 - [Extended conditions](#extended-conditions)
+- [Signals](#signals)
 - [Getting help](#getting-help)
 - [Getting involved](#getting-involved)
 - [Licensing](#licensing)
@@ -104,6 +105,31 @@ FLAGS = {
     ],
 }
 ```
+
+## Signals
+
+Wagtail-Flags includes  `flag_enabled` and `flag_disabled` signals that can be received when the "Enable for all requests" and "Disable for all requests" buttons are pressed in the admin. This is intended to enable things like front-end cache invalidation.
+
+```python
+from django.dispatch import receiver
+
+from wagtail.contrib.frontend_cache.utils import purge_url_from_cache
+
+from wagtailflags.signals import flag_disabled, flag_enabled
+
+
+@receiver(flag_enabled)
+def purge_on_flag_enabled(sender, **kwargs):
+    flag_name = kwargs["flag_name"]
+    purge_url_from_cache(...)
+
+@receiver(flag_disabled)
+def purge_on_flag_disabled(sender, **kwargs):
+    flag_name = kwargs["flag_name"]
+    purge_url_from_cache(...)
+```
+
+**Please note:** These signals are only sent for manual presses of the "Enable for all requests" and "Disable for all requests" buttons in the admin. Other flag conditions may vary within and only be valid for a specific request cycle.
 
 ## Getting help
 

--- a/wagtailflags/signals.py
+++ b/wagtailflags/signals.py
@@ -1,0 +1,5 @@
+from django.dispatch import Signal
+
+
+flag_disabled = Signal(providing_args=["instance", "flag_name"])
+flag_enabled = Signal(providing_args=["instance", "flag_name"])

--- a/wagtailflags/tests/test_signals.py
+++ b/wagtailflags/tests/test_signals.py
@@ -1,0 +1,37 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from wagtail.tests.utils import WagtailTestUtils
+
+from flags.models import FlagState
+
+from wagtailflags.signals import flag_disabled, flag_enabled
+
+
+class SignalsTestCase(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+        self.dbonly_flag = FlagState.objects.create(
+            name="DBONLY_FLAG",
+            condition="boolean",
+            value="True",
+            required=False,
+        )
+
+    def test_flag_enabled_was_sent(self):
+        mock_handler = mock.Mock()
+        flag_enabled.connect(mock_handler)
+        self.client.get("/admin/flags/FLAG_DISABLED/", {"enable": ""})
+        mock_handler.assert_called_with(
+            sender=mock.ANY, flag_name="FLAG_DISABLED", signal=mock.ANY
+        )
+
+    def test_flag_disabled_was_sent(self):
+        mock_handler = mock.Mock()
+        flag_disabled.connect(mock_handler)
+        self.client.get("/admin/flags/DBONLY_FLAG/", {"disable": ""})
+        mock_handler.assert_called_with(
+            sender=mock.ANY, flag_name="DBONLY_FLAG", signal=mock.ANY
+        )

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -8,6 +8,7 @@ from flags.sources import get_flags
 from flags.templatetags.flags_debug import bool_enabled
 
 from wagtailflags.forms import FlagStateForm, NewFlagForm
+from wagtailflags.signals import flag_disabled, flag_enabled
 
 
 def index(request):
@@ -70,8 +71,10 @@ def flag_index(request, name):
 
         if "enable" in request.GET and not bool_enabled(flag):
             boolean_condition_obj.value = True
+            flag_enabled.send(sender=flag_index, flag_name=flag.name)
         elif "disable" in request.GET and bool_enabled(flag):
             boolean_condition_obj.value = False
+            flag_disabled.send(sender=flag_index, flag_name=flag.name)
 
         boolean_condition_obj.save()
         return redirect("wagtailflags:flag_index", name=name)


### PR DESCRIPTION
This change adds `flag_enabled` and `flag_disabled` signals. When an admin user presses the "Enable" or "Disable" button for a flag in the admin, the appropriate signal will be sent, enabling things like cache invalidation to happen based on the flag being enabled for all requests or disabled for all requests.

This is not an attempt to add general-purpose flag state signaling. That's more complex because state can be dependent on a request. But Wagtail-Flags provides global "Enable"/"Disable" buttons for flags, and this should allow signal handlers based on that.

For a little more context, please see #40. This closes #40.