### PR TITLE
Add backwards-compatible SVG breadcrumb icons

### DIFF
--- a/wagtailflags/templates/wagtailflags/base.html
+++ b/wagtailflags/templates/wagtailflags/base.html
@@ -1,8 +1,0 @@
-{% extends "wagtailadmin/base.html" %}
-
-<ul class="breadcrumb">
-  <li class="home"><a href="#" class="icon icon-home text-replace">Home</a></li>
-  <li><a href="#">Various</a></li>
-  <li><a href="#">Subpages</a></li>
-  <li><a href="#">There is a max length of this many</a></li>
-</ul>

--- a/wagtailflags/templates/wagtailflags/includes/header.html
+++ b/wagtailflags/templates/wagtailflags/includes/header.html
@@ -1,9 +1,16 @@
-{% load wagtailflags_admin %}
+{% load wagtailadmin_tags wagtailflags_admin %}
+
 {% if flag %}
   <ul class="breadcrumb flags-breadcrumb">
-    <li><a href="{% url 'wagtailflags:list' %}">Flags</a></li>
-    <li>{{ title }}</li>
+      {% if wagtail_svg_crumbs %}
+        <li><a href="{% url 'wagtailflags:list' %}"><span class="title">Flags</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+        <li><a href="#"><span class="title">{{ title }}</span></a></li>
+      {% else %}
+        <li><a href="{% url 'wagtailflags:list' %}">Flags</a></li>
+        <li><a href="#">{{ title }}</a></li>
+      {% endif %}
   </ul>
+
   {% if flag|deletable %}
     {% if wagtail_header_action %}
       {% url 'wagtailflags:delete_flag' flag.name as delete_link %}

--- a/wagtailflags/templatetags/wagtailflags_admin.py
+++ b/wagtailflags/templatetags/wagtailflags_admin.py
@@ -1,5 +1,7 @@
 from django import template
 
+import wagtail
+
 from flags.sources import DatabaseCondition
 from flags.templatetags.flags_debug import bool_enabled
 
@@ -41,3 +43,14 @@ def deletable(flag):
     return flag.conditions and all(
         isinstance(c, DatabaseCondition) for c in flag.conditions
     )
+
+
+# Wagtail 2.10 adds the `icon` template tag, and Wagtail 2.11 uses it for
+# breadcrumbs. To support `icon` in our templates in 2.11+ and continue to
+# support Wagtail < 2.10, we define a placeholder here that will not be used
+# because we feature-fence its actual use at render-time.
+if wagtail.VERSION < (2, 10, 0):  # pragma: no cover
+
+    @register.simple_tag
+    def icon(name=None, class_name=None, title=None, wrapped=False):
+        pass

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -12,11 +12,18 @@ from wagtailflags.signals import flag_disabled, flag_enabled
 from wagtailflags.templatetags.wagtailflags_admin import deletable
 
 
+wagtailadmin_feature_context = {
+    # Wagtail 2.10 changes "add_*" in the shared admin header to "action_*"
+    "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
+    # Wagtail 2.11 changes the breadcrumb icons to SVGs
+    "wagtail_svg_crumbs": wagtail.VERSION >= (2, 11, 0),
+}
+
+
 def index(request):
     context = {
         "flags": sorted(get_flags().values(), key=lambda x: x.name),
-        # Wagtail 2.10 changes "add_*" in the shared admin header to "action_*"
-        "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
+        **wagtailadmin_feature_context,
     }
     return render(request, "wagtailflags/index.html", context)
 
@@ -40,7 +47,7 @@ def create_flag(request):
     else:
         form = NewFlagForm()
 
-    context = dict(form=form)
+    context = dict(form=form, **wagtailadmin_feature_context)
     return render(request, "wagtailflags/flags/create_flag.html", context)
 
 
@@ -58,10 +65,7 @@ def delete_flag(request, name):
         FlagState.objects.filter(name=name).delete()
         return redirect("wagtailflags:list")
 
-    context = {
-        "flag": flag,
-        "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
-    }
+    context = {"flag": flag, **wagtailadmin_feature_context}
     return render(request, "wagtailflags/flags/delete_flag.html", context)
 
 
@@ -101,10 +105,7 @@ def flag_index(request, name):
         boolean_condition_obj.save()
         return redirect("wagtailflags:flag_index", name=name)
 
-    context = {
-        "flag": flag,
-        "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
-    }
+    context = {"flag": flag, **wagtailadmin_feature_context}
     return render(request, "wagtailflags/flags/flag_index.html", context)
 
 
@@ -135,6 +136,7 @@ def edit_condition(request, name, condition_pk=None):
         "form": form,
         "condition_str": str(condition),
         "condition_pk": condition_pk,
+        **wagtailadmin_feature_context,
     }
     return render(request, "wagtailflags/flags/edit_condition.html", context)
 
@@ -155,5 +157,6 @@ def delete_condition(request, name, condition_pk):
         "flag": flag,
         "condition_str": str(condition),
         "condition_pk": condition.pk,
+        **wagtailadmin_feature_context,
     }
     return render(request, "wagtailflags/flags/delete_condition.html", context)


### PR DESCRIPTION
Wagtail 2.11 adds SVG icons to admin breadcrumbs. This PR adds those SVG icons to the Flags admin pages. It also adds a context variable to determine whether or not the SVG breadcrumb icons are available, and if not, falls back on the old style of breadcrumbs. I've also taken the opportunity to define this context variable and 2.10's "action" item change in a single location in `views.py`.

I'm not really satisfied with creating a placeholder `icon` template tag nor with the feature-fencing context variables passing to templates, but I'm not sure of a better way. I'm very open to alternatives.