### PR TITLE
Fix breadcrumbs in Wagtail 2.11, drop support for Wagtail < 2.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,20 +32,20 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-dj22-wag27
+            - py36-dj22-wag211
             - py36-dj22-waglatest
             - py36-dj31-waglatest
-            - py38-dj22-wag27
+            - py38-dj22-wag211
             - py38-dj22-waglatest
             - py38-dj31-waglatest
         include:
-          - toxenv: py36-dj22-wag27
+          - toxenv: py36-dj22-wag211
             python-version: 3.6
           - toxenv: py36-dj22-waglatest
             python-version: 3.6
           - toxenv: py36-dj31-waglatest
             python-version: 3.6
-          - toxenv: py38-dj22-wag27
+          - toxenv: py38-dj22-wag211
             python-version: 3.8
           - toxenv: py38-dj22-waglatest
             python-version: 3.8

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 - Python 3.6+
 - Django 2.2 (LTS), 3.1 (current)
 - Django-Flags 4.2 
-- Wagtail 2.7 (LTS), <3
+- Wagtail 2.11 (LTS), <3
 
 It should be compatible at all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-flags/issues/new).

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "wagtail>=2.7,<3",
+    "wagtail>=2.11,<3",
     "django-flags>=4.2,<5.1",
 ]
 
@@ -16,7 +16,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     license="CC0",
-    version="5.0.0",
+    version="5.1.0",
     include_package_data=True,
     packages=find_packages(),
     python_requires=">=3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,38}-dj{22,31}-wag{27,latest}
+    py{36,38}-dj{22,31}-wag{211,latest}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -20,7 +20,7 @@ basepython=
 deps=
     dj22:  Django>=2.2,<2.3
     dj31:  Django>=3.1,<3.2
-    wag27: wagtail>=2.7,<2.8
+    wag211: wagtail>=2.11,<2.12
     waglatest: wagtail<3
 
 [testenv:lint]

--- a/wagtailflags/templates/wagtailflags/base.html
+++ b/wagtailflags/templates/wagtailflags/base.html
@@ -1,8 +1,0 @@
-{% extends "wagtailadmin/base.html" %}
-
-<ul class="breadcrumb">
-  <li class="home"><a href="#" class="icon icon-home text-replace">Home</a></li>
-  <li><a href="#">Various</a></li>
-  <li><a href="#">Subpages</a></li>
-  <li><a href="#">There is a max length of this many</a></li>
-</ul>

--- a/wagtailflags/templates/wagtailflags/includes/header.html
+++ b/wagtailflags/templates/wagtailflags/includes/header.html
@@ -1,22 +1,18 @@
-{% load wagtailflags_admin %}
+{% load wagtailadmin_tags wagtailflags_admin %}
+
 {% if flag %}
   <ul class="breadcrumb flags-breadcrumb">
     <li><a href="{% url 'wagtailflags:list' %}">Flags</a></li>
     <li>{{ title }}</li>
   </ul>
+
   {% if flag|deletable %}
-    {% if wagtail_header_action %}
-      {% url 'wagtailflags:delete_flag' flag.name as delete_link %}
-      {# Wagtail 2.10 adds "action_*", which we need to enable the "Delete flag" button in the header. #}
-      {% include "wagtailadmin/shared/header.html" with title=title action_icon="bin" action_text='Delete flag' action_url=delete_link %}
-    {% endif %}
+    {% url 'wagtailflags:delete_flag' flag.name as delete_link %}
+    {% include "wagtailadmin/shared/header.html" with title=title action_icon="bin" action_text='Delete flag' action_url=delete_link %}
   {% else %}
     {% include "wagtailadmin/shared/header.html" with title=title icon=icon %}
   {% endif %}
-{% elif wagtail_header_action %}
-  {# Wagtail 2.10 changes "add_*" in the shared admin header to "action_*" #}
+{% else %}
   {% url 'wagtailflags:create_flag' as add_link %}
   {% include "wagtailadmin/shared/header.html" with title=title action_icon=icon action_text='Add flag' action_url=add_link %}
-{% else %}
-  {% include "wagtailadmin/shared/header.html" with title=title icon=icon add_text='Add flag' add_link='wagtailflags:create_flag' %}
 {% endif %}

--- a/wagtailflags/templates/wagtailflags/includes/header.html
+++ b/wagtailflags/templates/wagtailflags/includes/header.html
@@ -2,8 +2,8 @@
 
 {% if flag %}
   <ul class="breadcrumb flags-breadcrumb">
-    <li><a href="{% url 'wagtailflags:list' %}">Flags</a></li>
-    <li>{{ title }}</li>
+      <li><a href="{% url 'wagtailflags:list' %}"><span class="title">Flags</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+      <li><a href="#"><span class="title">{{ title }}</span></a></li>
   </ul>
 
   {% if flag|deletable %}

--- a/wagtailflags/views.py
+++ b/wagtailflags/views.py
@@ -1,8 +1,6 @@
 from django.http import Http404, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 
-import wagtail
-
 from flags.models import FlagState
 from flags.sources import get_flags
 from flags.templatetags.flags_debug import bool_enabled
@@ -15,8 +13,6 @@ from wagtailflags.templatetags.wagtailflags_admin import deletable
 def index(request):
     context = {
         "flags": sorted(get_flags().values(), key=lambda x: x.name),
-        # Wagtail 2.10 changes "add_*" in the shared admin header to "action_*"
-        "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
     }
     return render(request, "wagtailflags/index.html", context)
 
@@ -60,7 +56,6 @@ def delete_flag(request, name):
 
     context = {
         "flag": flag,
-        "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
     }
     return render(request, "wagtailflags/flags/delete_flag.html", context)
 
@@ -103,7 +98,6 @@ def flag_index(request, name):
 
     context = {
         "flag": flag,
-        "wagtail_header_action": wagtail.VERSION >= (2, 10, 0),
     }
     return render(request, "wagtailflags/flags/flag_index.html", context)
 


### PR DESCRIPTION
Wagtail 2.11 is the new LTS release, meaning we can drop support for 2.7. 

This change removes our 2.10-specific fencing around action links in the admin and drops support for Wagtail < 2.7. It also versions the next release as 5.1.0.

This change also uses fixes breadcrumbs in the admin by using Wagtail 2.11's SVG arrow icon.
