### PR TITLE
Update for Wagtail 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -32,30 +32,29 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-dj22-wag211
-            - py36-dj22-waglatest
-            - py39-dj22-wag211
-            - py39-dj22-waglatest
-            - py39-dj32-waglatest
+          # Legacy versions
+          - py39-dj32-wag215
+
+          # Current and latest versions
+          - py310-dj32-wag30
+          - py310-dj40-wag30
+          - py310-dj40-waglatest
+
         include:
-          - toxenv: py36-dj22-wag211
-            python-version: 3.6
-          - toxenv: py36-dj22-waglatest
-            python-version: 3.6
-          - toxenv: py39-dj22-waglatest
-            python-version: 3.9
-          - toxenv: py39-dj22-wag211
-            python-version: 3.9
-          - toxenv: py39-dj22-waglatest
-            python-version: 3.9
-          - toxenv: py39-dj32-waglatest
-            python-version: 3.9
+          - toxenv: py39-dj32-wag215
+            python-version: "3.9"
+          - toxenv: py310-dj32-wag30
+            python-version: "3.10"
+          - toxenv: py310-dj40-wag30
+            python-version: "3.10"
+          - toxenv: py310-dj40-waglatest
+            python-version: "3.10"
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -67,7 +66,39 @@ jobs:
       - name: Run tox
         run: |
             tox
-            coveralls
         env:
           TOXENV: ${{ matrix.toxenv }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+      - name: Store test coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: .coverage.*
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    needs:
+      - test
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Retrieve test coverage
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage
+
+      - name: Check coverage
+        run: tox -e coverage

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ __pycache__/
 #################
 htmlcov/
 .tox/
-.coverage
+.coverage*
 .cache
 nosetests.xml
 coverage.xml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/cfpb/wagtail-flags/badge.svg?branch=master)](https://coveralls.io/github/cfpb/wagtail-flags?branch=master)
 [![Ethical open source](https://img.shields.io/badge/open-ethical-%234baaaa)](https://ethicalsource.dev/definition/)
 
-Feature flags allow you to toggle functionality based on configurable conditions. 
+Feature flags allow you to toggle functionality based on configurable conditions.
 
 Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of [Django-Flags](https://github.com/cfpb/django-flags). For a more complete overview of feature flags and how to use them, please see the [Django-Flags documentation](https://cfpb.github.io/django-flags).
 
@@ -23,9 +23,9 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 ## Dependencies
 
 - Python 3.6+
-- Django 2.2 (LTS), 3.1 (current)
-- Django-Flags 4.2 
-- Wagtail 2.11 (LTS), <3
+- Django 3.2 (LTS), 4.0 (current)
+- Django-Flags 4.2
+- Wagtail 2.15 (LTS), 3.0
 
 It should be compatible at all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-flags/issues/new).
@@ -70,7 +70,7 @@ Then use the flag in a Django template (`mytemplate.html`):
 
 {% if my_flag %}
   <div class="flagged-banner">
-    I’m the result of a feature flag.   
+    I’m the result of a feature flag.
   </div>
 {% endif %}
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,22 +20,9 @@ exclude = '''
 )
 '''
 
-[tool.isort]
-profile = "black"
-line_length = 79
-lines_after_imports = 2
-skip = [".tox", "migrations", ".venv", "venv"]
-known_django = ["django"]
-known_wagtail = ["wagtail"]
-default_section = "THIRDPARTY"
-sections = [
-    "STDLIB",
-    "DJANGO",
-    "WAGTAIL",
-    "THIRDPARTY",
-    "FIRSTPARTY",
-    "LOCALFOLDER"
-]
-
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,76 @@
+[metadata]
+name = wagtail-flags
+version = 5.2.0
+author = CFPB
+author_email = tech@cfpb.gov
+description = Feature flags for Wagtail sites
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = CC0
+url = https://github.com/cfpb/wagtail-flags
+classifiers =
+    Operating System :: OS Independent
+    Framework :: Django
+    Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
+    Framework :: Wagtail
+    Framework :: Wagtail :: 2
+    Framework :: Wagtail :: 3
+    License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+    License :: Public Domain
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+
+[options]
+include_package_data = True
+packages = find:
+python_requires = >=3.8
+zip_safe = False
+install_requires =
+    wagtail>=2.15,<4
+    django-flags>=4.2,<5.1
+
+[options.extras_require]
+testing =
+    coverage
+
+[flake8]
+ignore = E731,W503,W504
+exclude =
+    .git,
+    .tox,
+    __pycache__,
+    */migrations/*.py,
+    .eggs/*,
+
+[isort]
+profile = black
+combine_as_imports = 1
+lines_after_imports = 2
+include_trailing_comma = 1
+multi_line_output = 3
+skip = .tox,migrations
+known_django = django
+known_wagtail = wagtail
+default_section = THIRDPARTY
+sections = FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+
+[mypy]
+allow_redefinition = false
+check_untyped_defs = true
+disallow_untyped_decorators = true
+disallow_any_explicit = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+ignore_errors = false
+ignore_missing_imports = true
+implicit_reexport = false
+local_partial_types = true
+strict_optional = true
+strict_equality = true
+no_implicit_optional = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_unused_configs = true
+warn_unreachable = true
+warn_no_return = true

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
-install_requires = [
-    "wagtail>=2.15,<4",
-    "django-flags>=4.2,<5.1",
-]
-
-testing_extras = ["coverage>=3.7.0"]
-
-setup(
-    name="wagtail-flags",
-    url="https://github.com/cfpb/wagtail-flags",
-    author="CFPB",
-    author_email="tech@cfpb.gov",
-    description="Feature flags for Wagtail sites",
-    long_description=open("README.md", "r", encoding="utf-8").read(),
-    long_description_content_type="text/markdown",
-    license="CC0",
-    version="5.2.0",
-    include_package_data=True,
-    packages=find_packages(),
-    python_requires=">=3.8",
-    install_requires=install_requires,
-    extras_require={"testing": testing_extras},
-    classifiers=[
-        "Framework :: Django",
-        "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
-        "Framework :: Wagtail",
-        "Framework :: Wagtail :: 2",
-        "Framework :: Wagtail :: 3",
-        "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
-        "License :: Public Domain",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-    ],
-)
+if __name__ == '__main__':
+    setup()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "wagtail>=2.11,<3",
+    "wagtail>=2.15,<4",
     "django-flags>=4.2,<5.1",
 ]
 
@@ -16,18 +16,19 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     license="CC0",
-    version="5.1.0",
+    version="5.2.0",
     include_package_data=True,
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     install_requires=install_requires,
     extras_require={"testing": testing_extras},
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.1",
+        "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
+        "Framework :: Wagtail :: 3",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "License :: Public Domain",
         "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands=
     isort --check-only --diff wagtailflags
 
 [testenv:coverage]
-basepython=python3.9
+basepython=python3.10
 deps=
     coverage
     diff_cover

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{22}-wag{211,latest},
-    py{39}-dj{22}-wag{211},
-    py{39}-dj{22,32}-wag{latest}
+    py{39,310}-dj{32,40}-wag{215,30,latest},
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,17 +14,18 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailflags.tests.settings
 
 basepython=
-    py36: python3.6
-    py39: python3.9
+    py39:  python3.9
+    py310: python3.10
 
 deps=
-    dj22:  Django>=2.2,<2.3
     dj32:  Django>=3.2,<3.3
-    wag211: wagtail>=2.11,<2.12
-    waglatest: wagtail<3
+    dj40:  Django>=4.0,<4.1
+    wag215: wagtail>=2.15,<2.16
+    wag30: wagtail>=3.0,<3.1
+    waglatest: wagtail<4
 
 [testenv:lint]
-basepython=python3.9
+basepython=python3.10
 deps=
     black
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,14 @@
 skipsdist=True
 envlist=
     lint,
-    py{39,310}-dj{32,40}-wag{215,30,latest},
+    py{39,310}-dj{32}-wag{215},
+    py{39,310}-dj{32,40}-wag{30,latest},
+    coverage
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
-    coverage erase
-    coverage run --source='wagtailflags' {envbindir}/django-admin.py test {posargs}
-    coverage report -m
+    python -b -m coverage run --parallel-mode --source='wagtailflags' {envbindir}/django-admin test {posargs}
 setenv=
     DJANGO_SETTINGS_MODULE=wagtailflags.tests.settings
 
@@ -31,27 +31,16 @@ deps=
     flake8
     isort
 commands=
-    black --check wagtailflags setup.py
-    flake8 wagtailflags setup.py
+    black --check wagtailflags
+    flake8 wagtailflags
     isort --check-only --diff wagtailflags
 
-[flake8]
-ignore=E731,W503,W504
-exclude=
-    .git,
-    .tox,
-    __pycache__,
-    */migrations/*.py,
-    .eggs/*,
-
-[isort]
-combine_as_imports=1
-lines_after_imports=2
-include_trailing_comma=1
-multi_line_output=3
-skip=.tox,migrations
-use_parentheses=1
-known_django=django
-known_wagtail=wagtail
-default_section=THIRDPARTY
-sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+[testenv:coverage]
+basepython=python3.9
+deps=
+    coverage
+    diff_cover
+commands=
+    coverage combine
+    coverage xml
+    diff-cover coverage.xml --compare-branch=origin/main --fail-under=100

--- a/wagtailflags/__init__.py
+++ b/wagtailflags/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "wagtailflags.apps.WagtailFlagsAppConfig"

--- a/wagtailflags/signals.py
+++ b/wagtailflags/signals.py
@@ -1,5 +1,5 @@
 from django.dispatch import Signal
 
 
-flag_disabled = Signal(providing_args=["instance", "flag_name"])
-flag_enabled = Signal(providing_args=["instance", "flag_name"])
+flag_disabled = Signal()
+flag_enabled = Signal()

--- a/wagtailflags/templates/wagtailflags/flags/create_flag.html
+++ b/wagtailflags/templates/wagtailflags/flags/create_flag.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}Create a flag{% endblock %}
 
 {% block content %}
@@ -31,7 +31,7 @@
             </li>
             <li class="actions">
                 <input class="button action-save button-longrunning" type="submit" value="Save flag" />
-                <a class="button bicolor icon icon-cog" href="{% url 'wagtailflags:list' %}">Back to flags</a>
+                <a class="button bicolor button--icon" href="{% url 'wagtailflags:list' %}">{% icon name="cog" wrapped=1 %} Back to flags</a>
             </li>
         </ul>
     </form>

--- a/wagtailflags/templates/wagtailflags/flags/edit_condition.html
+++ b/wagtailflags/templates/wagtailflags/flags/edit_condition.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n feature_flags %}
+{% load i18n feature_flags wagtailadmin_tags %}
 {% block titletag %}{% if form.instance %}Edit {{ form.instance.condition }} condition{% else %}Create condition{% endif %}{% endblock %}
 
 {% block content %}
@@ -47,7 +47,7 @@
 
             <li class="actions">
                 <input class="button action-save button-longrunning" type="submit" value="Save condition" />
-                <a class="button bicolor icon icon-cog" href="{% url 'wagtailflags:flag_index' flag.name %}">Back to {{ flag.name }}</a>
+                <a class="button bicolor button--icon" href="{% url 'wagtailflags:flag_index' flag.name %}">{% icon name="cog" wrapped=1 %} Back to {{ flag.name }}</a>
             </li>
         </ul>
     </form>

--- a/wagtailflags/templates/wagtailflags/includes/flag_index.html
+++ b/wagtailflags/templates/wagtailflags/includes/flag_index.html
@@ -1,13 +1,12 @@
-{% load i18n %}
-{% load wagtailflags_admin %}
-{% load i18n feature_flags flags_debug wagtailflags_admin %}
+{% load i18n wagtailadmin_tags %}
+{% load feature_flags flags_debug wagtailflags_admin %}
 
 <section class="flag" id="{{ flag.name }}">
     <div class="help-block help-info">
         <p>{{ flag|state_str }}</p>
     </div>
 
-    {% with flag|conditions_without_bool as conditions %}     
+    {% with flag|conditions_without_bool as conditions %}
         {% if conditions|length > 0 %}
         <table class="listing">
             <thead>
@@ -47,7 +46,7 @@
     {% endwith %}
 
     {% if flag|enablable or flag|disablable %}
-        <a href="{% url 'wagtailflags:flag_index' flag.name %}?{% if flag|bool_enabled %}disable{% else %}enable{% endif %}" 
+        <a href="{% url 'wagtailflags:flag_index' flag.name %}?{% if flag|bool_enabled %}disable{% else %}enable{% endif %}"
             class="button button-secondary{% if flag|bool_enabled %} no{% endif %}">
             {% if flag|bool_enabled %}Disable{% else %}Enable{% endif %} {{ flag.name }}
             {% if flag|required_conditions_without_bool|length > 0 %}
@@ -57,5 +56,5 @@
             {% endif %}
         </a>
     {% endif %}
-    <a href="{% url 'wagtailflags:create_condition' flag.name %}" class="button bicolor icon icon-plus">Add a condition</a>
+    <a href="{% url 'wagtailflags:create_condition' flag.name %}" class="button bicolor button--icon">{% icon name="plus" wrapped=1 %} Add a condition</a>
 </section>

--- a/wagtailflags/tests/settings.py
+++ b/wagtailflags/tests/settings.py
@@ -4,6 +4,7 @@ import wagtail
 
 ALLOWED_HOSTS = ["*"]
 
+USE_TZ = True
 SECRET_KEY = "not needed"
 
 ROOT_URLCONF = "wagtailflags.tests.urls"

--- a/wagtailflags/tests/settings.py
+++ b/wagtailflags/tests/settings.py
@@ -2,6 +2,7 @@ import os
 
 import wagtail
 
+
 ALLOWED_HOSTS = ["*"]
 
 USE_TZ = True

--- a/wagtailflags/tests/settings.py
+++ b/wagtailflags/tests/settings.py
@@ -1,5 +1,6 @@
 import os
 
+import wagtail
 
 ALLOWED_HOSTS = ["*"]
 
@@ -30,9 +31,7 @@ WAGTAIL_APPS = (
     "wagtail.contrib.forms",
     "wagtail.contrib.modeladmin",
     "wagtail.contrib.settings",
-    "wagtail.tests.testapp",
     "wagtail.admin",
-    "wagtail.core",
     "wagtail.documents",
     "wagtail.images",
     "wagtail.sites",
@@ -41,8 +40,25 @@ WAGTAIL_APPS = (
 
 WAGTAILADMIN_RICH_TEXT_EDITORS = {
     "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
-    "custom": {"WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"},
 }
+
+# Wagtail 3.0 moves testapp from wagtail.tests to wagtail.test
+if wagtail.VERSION >= (3, 0, 0):  # pragma: no cover
+    WAGTAIL_APPS += (
+        "wagtail",
+        "wagtail.test.testapp",
+    )
+    WAGTAILADMIN_RICH_TEXT_EDITORS["custom"] = {
+        "WIDGET": "wagtail.test.testapp.rich_text.CustomRichTextArea"
+    }
+else:  # pragma: no cover
+    WAGTAIL_APPS += (
+        "wagtail.core",
+        "wagtail.tests.testapp",
+    )
+    WAGTAILADMIN_RICH_TEXT_EDITORS["custom"] = {
+        "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
+    }
 
 MIDDLEWARE = (
     "django.middleware.common.CommonMiddleware",

--- a/wagtailflags/tests/test_conditions.py
+++ b/wagtailflags/tests/test_conditions.py
@@ -1,11 +1,16 @@
 from django.test import RequestFactory, TestCase
 
 import wagtail
-from wagtail.core.models import Site
 
 from flags.conditions import RequiredForCondition
 
 from wagtailflags.conditions import site_condition
+
+
+if wagtail.VERSION > (3, 0, 0):  # pragma: no cover
+    from wagtail.models import Site
+else:  # pragma: no cover
+    from wagtail.core.models import Site
 
 
 class SiteConditionTestCase(TestCase):
@@ -13,10 +18,7 @@ class SiteConditionTestCase(TestCase):
         self.site = Site.objects.get(is_default_site=True)
         self.factory = RequestFactory()
         self.request = self.factory.get("/")
-        if wagtail.VERSION >= (2, 9):  # pragma: no cover
-            Site.find_for_request(self.request)
-        else:  # pragma: no cover
-            self.request.site = self.site
+        Site.find_for_request(self.request)
 
     def test_site_valid_string(self):
         self.assertTrue(site_condition("localhost:80", request=self.request))

--- a/wagtailflags/tests/test_signals.py
+++ b/wagtailflags/tests/test_signals.py
@@ -2,11 +2,17 @@ from unittest import mock
 
 from django.test import TestCase
 
-from wagtail.tests.utils import WagtailTestUtils
+import wagtail
 
 from flags.models import FlagState
 
 from wagtailflags.signals import flag_disabled, flag_enabled
+
+
+if wagtail.VERSION >= (3, 0, 0):  # pragma: no cover
+    from wagtail.test.utils import WagtailTestUtils
+else:  # pragma: no cover
+    from wagtail.tests.utils import WagtailTestUtils
 
 
 class SignalsTestCase(TestCase, WagtailTestUtils):

--- a/wagtailflags/tests/test_views.py
+++ b/wagtailflags/tests/test_views.py
@@ -1,8 +1,14 @@
 from django.test import TestCase
 
-from wagtail.tests.utils import WagtailTestUtils
+import wagtail
 
 from flags.models import FlagState
+
+
+if wagtail.VERSION >= (3, 0, 0):  # pragma: no cover
+    from wagtail.test.utils import WagtailTestUtils
+else:  # pragma: no cover
+    from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestWagtailFlagsViews(TestCase, WagtailTestUtils):

--- a/wagtailflags/tests/urls.py
+++ b/wagtailflags/tests/urls.py
@@ -1,11 +1,6 @@
+from django.urls import include, re_path
+
 from wagtail.admin import urls as wagtailadmin_urls
-
-
-try:  # pragma: no cover; >= 2.0
-    from django.urls import include, re_path
-except ImportError:  # pragma: no cover; fallback for Django < 2.0
-    from django.conf.urls import include
-    from django.conf.urls import url as re_path
 
 
 urlpatterns = [

--- a/wagtailflags/wagtail_hooks.py
+++ b/wagtailflags/wagtail_hooks.py
@@ -2,18 +2,18 @@ import django
 from django.templatetags.static import static
 from django.utils.html import format_html
 
+import wagtail
 from wagtail.admin.menu import MenuItem
-from wagtail.core import hooks
 
 from wagtailflags import views
 
 
-try:  # pragma: no cover; >= 2.0
-    from django.urls import include, re_path, reverse
-except ImportError:  # pragma: no cover; fallback for Django < 2.0
-    from django.conf.urls import include
-    from django.conf.urls import url as re_path
-    from django.core.urlresolvers import reverse
+if wagtail.VERSION >= (3, 0, 0):  # pragma: no cover
+    from wagtail import hooks
+else:  # pragma: no cover
+    from wagtail.core import hooks
+
+from django.urls import include, re_path, reverse
 
 
 @hooks.register("register_settings_menu_item")
@@ -21,7 +21,7 @@ def register_flags_menu():
     return MenuItem(
         "Flags",
         reverse("wagtailflags:list"),
-        classnames="icon icon-tag",
+        icon_name="tag",
         order=10000,
     )
 


### PR DESCRIPTION
This PR updates Wagtail-Flags for Wagtail 3.0 and Django 4.0. This PR also drops support for Wagtail < 2.15 (the current LTS release) and Django < 3.2 (the current LTS release).

Wagtail 3.0 support requires some minor adjustments to our Wagtail imports and icon usage. SVG icons were introduced before 2.15. Django 4.0 support requires some minor adjustments to our application config and signals.

I've made the appropriate changes to our tox test matrix, and while in here, I've also converted the setup.py options to setup.cfg and moved the flake8 and isort configuration there. 