### PR TITLE
Fix classname deprecation warning in Wagtail 4.2

### DIFF
--- a/wagtailflags/templates/wagtailflags/includes/flag_breadcrumbs.html
+++ b/wagtailflags/templates/wagtailflags/includes/flag_breadcrumbs.html
@@ -17,7 +17,7 @@ This implementation borrows heavily from `wagtailsnippets/snippets/headers/_base
                 aria-label="{% trans 'Toggle breadcrumbs' %}"
                 aria-expanded="false"
             >
-                {% icon name="breadcrumb-expand" class_name="w-w-4 w-h-4" %}
+                {% icon name="breadcrumb-expand" classname="w-w-4 w-h-4" %}
             </button>
 
             <div class="w-relative w-h-slim-header w-mr-4 w-top-0 w-z-20 w-flex w-items-center w-flex-row w-flex-1 sm:w-flex-none w-transition w-duration-300">
@@ -28,7 +28,7 @@ This implementation borrows heavily from `wagtailsnippets/snippets/headers/_base
                                 <a class="{{ breadcrumb_link_classes }}" href="{% url 'wagtailflags:list' %}">
                                     {% trans 'Flags' %}
                                 </a>
-                                {% icon name="arrow-right" class_name=icon_classes %}
+                                {% icon name="arrow-right" classname=icon_classes %}
                             </li>
                             {% if flag %}
                             <li class="{{ breadcrumb_item_classes }}">


### PR DESCRIPTION
Wagtail 4.2 deprecates use of the `class_name` attribute in the icon tag.
This commit replaces it with `classname` instead. See:

https://docs.wagtail.org/en/stable/releases/4.2.html#adoption-of-classname-convention-for-some-template-tags-includes