### PR TITLE
Update package tooling and boilerplate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |
@@ -31,29 +31,24 @@ jobs:
 
     strategy:
       matrix:
-        toxenv:
-            - py38-dj3-wag4
-            - py38-dj4-wag4
-            - py38-dj3-waglatest
-            - py38-dj4-waglatest
-
+        python: ['3.12']
+        django: ['4.2', '5.0']
+        wagtail: ['6.0', '6.1']
         include:
-          - toxenv: py38-dj3-wag4
-            python-version: 3.8
-          - toxenv: py38-dj4-wag4
-            python-version: 3.8
-          - toxenv: py38-dj3-waglatest
-            python-version: 3.8
-          - toxenv: py38-dj4-waglatest
-            python-version: 3.8
+          - python: '3.8'
+            django: '4.2'
+            wagtail: '6.0'
+          - python: '3.8'
+            django: '4.2'
+            wagtail: '6.1'
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python}}
 
       - name: Install dependencies
         run: |
@@ -61,15 +56,15 @@ jobs:
           pip install tox coveralls
 
       - name: Run tox
-        run: |
-            tox
+        run: tox
         env:
-          TOXENV: ${{ matrix.toxenv }}
+          TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
+
 
       - name: Store test coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.python }}-${{ matrix.django }}-${{ matrix.wagtail }}
           path: .coverage.*
 
   coverage:
@@ -79,23 +74,24 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install tox
+
       - name: Retrieve test coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: coverage
+          merge-multiple: true
 
       - name: Check coverage
         run: tox -e coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,15 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-    - id: black
-      args: ["wagtailflags", "setup.py", "--line-length=79"]
-      exclude: migrations
--   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.188
-    hooks:
-    - id: ruff
--   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: ["wagtailflags"]
+-  repo: https://github.com/charliermarsh/ruff-pre-commit
+   rev: v0.5.0
+   hooks:
+     # Run the linter.
+     - id: ruff
+       args: ['--fix']
+     # Run the formatter.
+     - id: ruff-format
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.8
+  hooks:
+    - id: bandit
+      args: ['-c', 'pyproject.toml', '--recursive']
+      additional_dependencies: ['bandit[toml]']

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 ## Dependencies
 
 - Python 3.8+
-- Django 3.2 (LTS)+
-- Django-Flags 4.2
-- Wagtail 4.0+
+- Django 4.2 (LTS)+
+- Django-Flags 5.0
+- Wagtail 6.0+
 
 It should be compatible at all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-flags/issues/new).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+requires = ["setuptools>=63", "setuptools_scm[toml]>=8"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "wagtail-flags"
-version = "5.3.1"
+dynamic = ["version"]
 description = "Feature flags for Wagtail sites"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -9,19 +13,15 @@ authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]
 dependencies = [
-    "wagtail>=4",
-    "django-flags>4.2"
+    "wagtail>6",
+    "django-flags>5"
 ]
 classifiers = [
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 4",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
 ]
 
 [project.optional-dependencies]
@@ -34,10 +34,6 @@ testing = [
 "Bug Reports" = "https://github.com/cfpb/wagtail-flags/issues"
 "Source" = "https://github.com/cfpb/wagtail-flags"
 
-[build-system]
-requires = ["setuptools>=43.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [tool.setuptools.package-data]
 wagtailflags = [
     "templates/wagtailflags/*",
@@ -46,57 +42,60 @@ wagtailflags = [
     "static/wagtailflags/css/*",
 ]
 
-[tool.black]
-line-length = 79
-target-version = ["py38"]
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs
-    | \.git
-    | \.tox
-    | \*.egg-info
-    | _build
-    | build
-    | dist
-    | migrations
-    | site
-  )/
-)
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 79
-lines_after_imports = 2
-skip = [".tox", ".venv", "venv"]
-known_django = ["django"]
-known_wagtail = ["wagtail"]
-default_section = "THIRDPARTY"
-sections = [
-    "STDLIB",
-    "DJANGO",
-    "WAGTAIL",
-    "THIRDPARTY",
-    "FIRSTPARTY",
-    "LOCALFOLDER"
-]
+[tool.setuptools_scm]
 
 [tool.ruff]
+# Use PEP8 line-length
+line-length = 79
+# Exclude common paths
 exclude = [
     ".git",
     ".tox",
     "__pycache__",
+    "**/migrations/*.py",
 ]
-ignore = []
+
+[tool.ruff.lint]
+ignore = ["E731", ]
+# Select specific rulesets to use
 select = [
+    # pycodestyle
     "E",
+    # pyflakes
     "F",
-    "W",
+    # flake8-bugbear
+    "B",
+    # pyupgrade
+    "UP",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
+
+[tool.ruff.lint.isort.sections]
+"django" = ["django"]
+"wagtail" = ["wagtail"]
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+known-third-party = ["jinja2"]
+section-order = [
+    "future",
+    "standard-library",
+    "django",
+    "wagtail",
+    "third-party",
+    "first-party",
+    "local-folder",
 ]
 
 [tool.coverage.run]
 omit = [
     "wagtailflags/tests/*",
+]
+
+[tool.bandit]
+exclude_dirs = [
+    "*/tests/*",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{38,311}-dj{3,4}-wag{4,latest},
+    python3.8-django4.2-wagtail6.0,
+    python3.12-django{4.2,5.0}-wagtail{6.0,6.1}
     coverage
 
 [testenv]
@@ -13,28 +14,27 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailflags.tests.settings
 
 basepython=
-    py38:  python3.8
-    py311: python3.11
+    python3.8:  python3.8
+    python3.12: python3.12
 
 deps=
-    dj3:  Django>=3.2,<4
-    dj4:  Django>=4.1,<5
-    wag4: wagtail>=4,<5
-    waglatest: wagtail>4
+    django4.2:  Django>=4.2,<5
+    django5.0:  Django>=5.0,<5.1
+    wagtail6.0: wagtail>=6.0,<6.1
+    wagtail6.1: wagtail>=6.1,<6.2
 
 [testenv:lint]
-basepython=python3.8
+basepython=python3.12
 deps=
-    black
     ruff
-    isort
+    bandit
 commands=
-    black --check wagtailflags
-    ruff wagtailflags
-    isort --check-only --diff wagtailflags
+    ruff format --check
+    ruff check wagtailflags
+    bandit -c "pyproject.toml" -r wagtailflags
 
 [testenv:coverage]
-basepython=python3.8
+basepython=python3.12
 deps=
     coverage
     diff_cover
@@ -44,10 +44,10 @@ commands=
     diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:interactive]
-basepython=python3.8
+basepython=python3.12
 
 deps=
-    Django>=3.2,<3.3
+    Django>=5.0,<5.1
 
 commands_pre=
     {envbindir}/django-admin makemigrations

--- a/wagtailflags/forms.py
+++ b/wagtailflags/forms.py
@@ -11,13 +11,11 @@ class NewFlagForm(forms.ModelForm):
     def clean_name(self):
         name = self.cleaned_data["name"]
         if name in get_flags():
-            raise forms.ValidationError(
-                "Flag named {} already exists".format(name)
-            )
+            raise forms.ValidationError(f"Flag named {name} already exists")
         return name
 
     def save(self, commit=True):
-        obj = super(NewFlagForm, self).save(commit=False)
+        obj = super().save(commit=False)
         obj.condition = "boolean"
         obj.value = "False"
         obj.required = False

--- a/wagtailflags/tests/settings.py
+++ b/wagtailflags/tests/settings.py
@@ -45,7 +45,6 @@ INSTALLED_APPS = (
     "taggit",
     "wagtail",
     "wagtail.contrib.forms",
-    "wagtail.contrib.modeladmin",
     "wagtail.contrib.settings",
     "wagtail.admin",
     "wagtail.documents",

--- a/wagtailflags/tests/test_views.py
+++ b/wagtailflags/tests/test_views.py
@@ -161,7 +161,7 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
             name="DBONLY_FLAG", condition="boolean", value="true"
         )
         response = self.client.get(
-            "/admin/flags/DBONLY_FLAG/{}/".format(condition_obj.pk)
+            f"/admin/flags/DBONLY_FLAG/{condition_obj.pk}/"
         )
         self.assertEqual(response.status_code, 200)
 
@@ -171,7 +171,7 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         }
 
         response = self.client.post(
-            "/admin/flags/DBONLY_FLAG/{}/".format(condition_obj.pk), params
+            f"/admin/flags/DBONLY_FLAG/{condition_obj.pk}/", params
         )
         self.assertRedirects(response, "/admin/flags/DBONLY_FLAG/")
         self.assertEqual(
@@ -190,12 +190,12 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         )
         self.assertEqual(len(FlagState.objects.all()), 2)
         response = self.client.get(
-            "/admin/flags/DBONLY_FLAG/{}/delete/".format(condition_obj.pk)
+            f"/admin/flags/DBONLY_FLAG/{condition_obj.pk}/delete/"
         )
         self.assertEqual(response.status_code, 200)
 
         response = self.client.post(
-            "/admin/flags/DBONLY_FLAG/{}/delete/".format(condition_obj.pk)
+            f"/admin/flags/DBONLY_FLAG/{condition_obj.pk}/delete/"
         )
         self.assertRedirects(response, "/admin/flags/DBONLY_FLAG/")
         self.assertEqual(len(FlagState.objects.all()), 1)


### PR DESCRIPTION
This change updates our tooling to make a few changes and updates:

- Use Ruff exclusively for formatting, linting, and import-sorting. Ruff can replace Black and isort, and is faster.
- Add Bandit for static security analysis.
- Move to pyproject.toml
- Add setuptools_scm for versioning. This will mean we don't have to manually update a version number in pyproject.toml.
- Run `ruff check --fix` for linting fixes
- Updates our officially supported versions of Django, Wagtail, and Django-Flags to the most recent versions