### PR TITLE
Fix non-alphanumeric characters in flag names

### DIFF
--- a/wagtailflags/forms.py
+++ b/wagtailflags/forms.py
@@ -6,7 +6,7 @@ from flags.sources import get_flags
 
 
 class NewFlagForm(forms.ModelForm):
-    name = forms.CharField(label="Name", required=True)
+    name = forms.SlugField(label="Name", required=True)
 
     def clean_name(self):
         name = self.cleaned_data["name"]

--- a/wagtailflags/wagtail_hooks.py
+++ b/wagtailflags/wagtail_hooks.py
@@ -1,6 +1,5 @@
-import django
 from django.templatetags.static import static
-from django.urls import include, re_path, reverse
+from django.urls import include, path, reverse
 from django.utils.html import format_html
 
 from wagtail import hooks
@@ -22,47 +21,37 @@ def register_flags_menu():
 @hooks.register("register_admin_urls")
 def register_flag_admin_urls():
     flagpatterns = [
-        re_path(r"^$", views.index, name="list"),
-        re_path(r"^create/$", views.create_flag, name="create_flag"),
-        re_path(r"^(?P<name>[\w\-]+)/$", views.flag_index, name="flag_index"),
-        re_path(
-            r"^(?P<name>[\w\-]+)/delete/$",
+        path("", views.index, name="list"),
+        path("create/", views.create_flag, name="create_flag"),
+        path("<name>/", views.flag_index, name="flag_index"),
+        path(
+            "<name>/delete/",
             views.delete_flag,
             name="delete_flag",
         ),
-        re_path(
-            r"^(?P<name>[\w\-]+)/create/$",
+        path(
+            "<name>/create/",
             views.edit_condition,
             name="create_condition",
         ),
-        re_path(
-            r"^(?P<name>[\w\-]+)/(?P<condition_pk>\d+)/$",
+        path(
+            "<name>/<int:condition_pk>/",
             views.edit_condition,
             name="edit_condition",
         ),
-        re_path(
-            r"^(?P<name>[\w\-]+)/(?P<condition_pk>\d+)/delete/$",
+        path(
+            "<name>/<int:condition_pk>/delete/",
             views.delete_condition,
             name="delete_condition",
         ),
     ]
 
-    if django.VERSION >= (1, 10):  # pragma: no cover
-        urlpatterns = [
-            re_path(
-                r"^flags/",
-                include(
-                    (flagpatterns, "wagtailflags"), namespace="wagtailflags"
-                ),
-            )
-        ]
-    else:  # pragma: no cover; fallback for Django < 1.10
-        urlpatterns = [
-            re_path(
-                r"^flags/",
-                include((flagpatterns, "wagtailflags", "wagtailflags")),
-            )
-        ]
+    urlpatterns = [
+        path(
+            "flags/",
+            include((flagpatterns, "wagtailflags"), namespace="wagtailflags"),
+        )
+    ]
 
     return urlpatterns
 


### PR DESCRIPTION
As @chosak notes in #73, the admin URL patterns prevented creating flags that didn't match `[\w\-]`. This change fixes that by switching from `re_path` to `path` for those patterns, simplifying them and making them more readable.

Fixes #73