### PR TITLE
Support Python 3.13, drop support for < 3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,16 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.12
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip build
-    - name: Build the package
-      run: |
-        python -m build
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip build
+      - name: Build the package
+        run: |
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,17 +3,16 @@ name: test
 on: [pull_request, push]
 
 jobs:
-
   lint:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -31,22 +30,19 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.12']
-        django: ['4.2', '5.0']
-        wagtail: ['6.0', '6.1']
+        python: ["3.12", "3.13"]
+        django: ["5.1", "5.2"]
+        wagtail: ["6.3", "6.4"]
         include:
-          - python: '3.8'
-            django: '4.2'
-            wagtail: '6.0'
-          - python: '3.8'
-            django: '4.2'
-            wagtail: '6.1'
+          - python: "3.10"
+            django: "4.2"
+            wagtail: "6.2"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python}}
 
@@ -60,11 +56,11 @@ jobs:
         env:
           TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
 
-
       - name: Store test coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-${{ matrix.python }}-${{ matrix.django }}-${{ matrix.wagtail }}
+          include-hidden-files: true
           path: .coverage.*
 
   coverage:
@@ -74,14 +70,14 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -89,7 +85,7 @@ jobs:
           pip install tox
 
       - name: Retrieve test coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           merge-multiple: true
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 
 ## Dependencies
 
-- Python 3.8+
+- Python 3.10+
 - Django 4.2 (LTS)+
 - Django-Flags 5.0
-- Wagtail 6.0+
+- Wagtail 6.2+
 
 It should be compatible at all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-flags/issues/new).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ name = "wagtail-flags"
 dynamic = ["version"]
 description = "Feature flags for Wagtail sites"
 readme = "README.md"
-requires-python = ">=3.8"
-license = {text = "CC0"}
+requires-python = ">=3.10"
+license = "CC0-1.0"
 authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]
@@ -18,10 +18,17 @@ dependencies = [
 ]
 classifiers = [
     "Framework :: Django",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
-    "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
-    "License :: Public Domain",
+    "Framework :: Wagtail :: 6",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    python3.8-django4.2-wagtail6.0,
-    python3.12-django{4.2,5.0}-wagtail{6.0,6.1}
+    python{3.10,3.13}-django4.2-wagtail6.2,
+    python{3.12,3.13}-django{5.1,5.2}-wagtail{6.3,6.4}
     coverage
 
 [testenv]
@@ -14,17 +14,20 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailflags.tests.settings
 
 basepython=
-    python3.8:  python3.8
+    python3.10: python3.10
     python3.12: python3.12
+    python3.13: python3.13
 
 deps=
-    django4.2:  Django>=4.2,<5
-    django5.0:  Django>=5.0,<5.1
-    wagtail6.0: wagtail>=6.0,<6.1
-    wagtail6.1: wagtail>=6.1,<6.2
+    django4.2: Django>=4.2,<5.0
+    django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
+    wagtail6.2: wagtail>=6.2,<6.3
+    wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
 
 [testenv:lint]
-basepython=python3.12
+basepython=python3.13
 deps=
     ruff
     bandit
@@ -34,7 +37,7 @@ commands=
     bandit -c "pyproject.toml" -r wagtailflags
 
 [testenv:coverage]
-basepython=python3.12
+basepython=python3.13
 deps=
     coverage
     diff_cover
@@ -44,10 +47,10 @@ commands=
     diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:interactive]
-basepython=python3.12
+basepython=python3.13
 
 deps=
-    Django>=5.0,<5.1
+    Django>=5.2,<5.3
 
 commands_pre=
     {envbindir}/django-admin makemigrations

--- a/wagtailflags/conditions.py
+++ b/wagtailflags/conditions.py
@@ -9,9 +9,7 @@ def site_condition(site_str, request=None, **kwargs):
     """Does the requests's Wagtail Site match the given site?
     site_str should be 'hostname:port', or 'hostname [default]'."""
     if request is None:
-        raise RequiredForCondition(
-            "request is required for condition " "'site'"
-        )
+        raise RequiredForCondition("request is required for condition 'site'")
 
     Site = apps.get_model("wagtailcore.Site")
 


### PR DESCRIPTION
This commit adds support for Python 3.13, drops support for EOL Python (< 3.10), and makes a few minor changes to tox, GitHub Actions, and elsewhere to support this update.

I've also replaced the deprecated `license` specification in pyproject.toml with the SPDX CC0 string, per PEP 639.