### PR TITLE
Add Wagtail 7 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -35,7 +35,7 @@ jobs:
         wagtail: ["6.3", "6.4", "7.0"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -53,7 +53,7 @@ jobs:
           TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
 
       - name: Store test coverage
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.python }}-${{ matrix.django }}-${{ matrix.wagtail }}
           include-hidden-files: true
@@ -66,7 +66,7 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
           pip install tox
 
       - name: Retrieve test coverage
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           merge-multiple: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,12 +31,8 @@ jobs:
     strategy:
       matrix:
         python: ["3.12", "3.13"]
-        django: ["5.1", "5.2"]
-        wagtail: ["6.3", "6.4"]
-        include:
-          - python: "3.10"
-            django: "4.2"
-            wagtail: "6.2"
+        django: ["5.2"]
+        wagtail: ["6.3", "6.4", "7.0"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
--  repo: https://github.com/charliermarsh/ruff-pre-commit
-   rev: v0.5.0
-   hooks:
-     # Run the linter.
-     - id: ruff
-       args: ['--fix']
-     # Run the formatter.
-     - id: ruff-format
-- repo: https://github.com/PyCQA/bandit
-  rev: 1.7.8
-  hooks:
-    - id: bandit
-      args: ['-c', 'pyproject.toml', '--recursive']
-      additional_dependencies: ['bandit[toml]']
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.9
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+        args: ["--fix"]
+      # Run the formatter.
+      - id: ruff-format
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml", "--recursive"]
+        additional_dependencies: ["bandit[toml]"]

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Wagtail-Flags adds a Wagtail admin UI and Wagtail Site-based condition on top of
 
 ## Dependencies
 
-- Python 3.10+
-- Django 4.2 (LTS)+
+- Python 3.12+
+- Django 5.2 (LTS)+
 - Django-Flags 5.0
-- Wagtail 6.2+
+- Wagtail 6.3+
 
 It should be compatible at all intermediate versions, as well.
 If you find that it is not, please [file an issue](https://github.com/cfpb/wagtail-flags/issues/new).
@@ -40,13 +40,13 @@ pip install wagtail-flags
 
 2. Add `flags` and `wagtailflags` as installed apps in your Django `settings.py`:
 
- ```python
- INSTALLED_APPS = (
-     ...
-     'flags',
-     'wagtailflags',
-     ...
- )
+```python
+INSTALLED_APPS = (
+    ...
+    'flags',
+    'wagtailflags',
+    ...
+)
 ```
 
 ## Usage
@@ -107,7 +107,7 @@ FLAGS = {
 
 ## Signals
 
-Wagtail-Flags includes  `flag_enabled` and `flag_disabled` signals that can be received when the "Enable for all requests" and "Disable for all requests" buttons are pressed in the admin. This is intended to enable things like front-end cache invalidation.
+Wagtail-Flags includes `flag_enabled` and `flag_disabled` signals that can be received when the "Enable for all requests" and "Disable for all requests" buttons are pressed in the admin. This is intended to enable things like front-end cache invalidation.
 
 ```python
 from django.dispatch import receiver
@@ -139,6 +139,7 @@ Please add issues to the [issue tracker](https://github.com/cfpb/wagtail-flags/i
 General instructions on _how_ to contribute can be found in [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Licensing
+
 1. [TERMS](TERMS.md)
 2. [LICENSE](LICENSE)
 3. [CFPB Source Code Policy](https://github.com/cfpb/source-code-policy/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "wagtail-flags"
 dynamic = ["version"]
 description = "Feature flags for Wagtail sites"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = "CC0-1.0"
 authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
@@ -18,15 +18,12 @@ dependencies = [
 ]
 classifiers = [
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.10,3.13}-django4.2-wagtail6.2,
-    python{3.12,3.13}-django{5.1,5.2}-wagtail{6.3,6.4}
+    python{3.12,3.13}-django{5.2}-wagtail{6.3,6.4,7.0}
     coverage
 
 [testenv]
@@ -14,17 +13,14 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailflags.tests.settings
 
 basepython=
-    python3.10: python3.10
     python3.12: python3.12
     python3.13: python3.13
 
 deps=
-    django4.2: Django>=4.2,<5.0
-    django5.1: Django>=5.1,<5.2
     django5.2: Django>=5.2,<5.3
-    wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 
 [testenv:lint]
 basepython=python3.13
@@ -51,6 +47,7 @@ basepython=python3.13
 
 deps=
     Django>=5.2,<5.3
+    wagtail>=7.0,<7.1
 
 commands_pre=
     {envbindir}/django-admin makemigrations


### PR DESCRIPTION
- Add Wagtail 7 support 
- Drop django 4.2 and 5.1 support
- Drop python 3.10 support
- Bump all actions to latest versions
- Update pre-commit config to latest